### PR TITLE
feat(phyai): radix prefix-cache bridge for AR attention

### DIFF
--- a/phyai/src/phyai/layers/attention/ar/__init__.py
+++ b/phyai/src/phyai/layers/attention/ar/__init__.py
@@ -36,3 +36,23 @@ __all__ = [
     "list_backends",
     "register_backend",
 ]
+
+# RadixAttentionPlanner / RadixSequence are intentionally NOT in __all__: they
+# are lazily re-exported via __getattr__ below (the radix bridge pulls in the
+# optional ``phyai-ext`` extra). Keeping them out of __all__ means
+# ``from ...ar import *`` does not eagerly resolve them and so does not require
+# the extension. Import them explicitly: ``from ...ar import RadixAttentionPlanner``.
+
+
+def __getattr__(name: str):
+    # Lazy re-export: the radix bridge pulls in the optional ``phyai-ext``
+    # extra, so importing the base AR package (layers/backends) must not import
+    # it eagerly. Resolved on first attribute access.
+    # See tests/.../test_radix_planner.py::test_ar_import_does_not_pull_radix_extension.
+    if name in ("RadixAttentionPlanner", "RadixSequence"):
+        from phyai.layers.attention.ar import radix
+
+        value = getattr(radix, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/phyai/src/phyai/layers/attention/ar/radix/__init__.py
+++ b/phyai/src/phyai/layers/attention/ar/radix/__init__.py
@@ -1,0 +1,16 @@
+"""Radix-cache → AR attention bridge.
+
+:class:`RadixAttentionPlanner` turns per-request :class:`RadixSequence`
+objects (pre-encoded ``atoms``) into prefix-reusing
+:class:`~phyai.layers.attention.ar.base.ARAttnMetadata` on top of
+:class:`phyai_ext.radix_cache.PrefixCache`. Model- and encoding-agnostic;
+the foundation a radix-enabled AR runner (e.g. cosmos) builds on.
+"""
+
+from __future__ import annotations
+
+from phyai.layers.attention.ar.radix.planner import RadixAttentionPlanner
+from phyai.layers.attention.ar.radix.sequence import RadixSequence
+
+
+__all__ = ["RadixAttentionPlanner", "RadixSequence"]

--- a/phyai/src/phyai/layers/attention/ar/radix/planner.py
+++ b/phyai/src/phyai/layers/attention/ar/radix/planner.py
@@ -1,0 +1,335 @@
+"""Radix-cache → :class:`ARAttnMetadata` bridge for the AR attention stack.
+
+:class:`RadixAttentionPlanner` is the per-request lifecycle glue between
+:class:`phyai_ext.radix_cache.PrefixCache` and the paged AR attention
+backends. It implements the prefill-with-prefix contract: match the
+longest cached prefix, reuse those slots, allocate only the uncached
+suffix, build an :class:`ARAttnMetadata` whose query is the suffix tokens
+(KV = prefix + suffix), and — after the forward writes the suffix K/V —
+``insert`` the suffix back into the tree for future reuse.
+
+Model- and encoding-agnostic: callers hand it :class:`RadixSequence`
+objects carrying pre-encoded ``atoms`` (see
+:mod:`phyai.cache.radix_cache.encoding`). pi0.5 keeps its ``StaticCache``
+path; this is the foundation a radix-enabled AR runner (e.g. cosmos)
+builds on.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from phyai_ext.radix_cache import PrefixCache, Tier
+
+from phyai.cache.kv_cache_pool import KVCachePool
+from phyai.layers.attention.ar.base import ARAttnMetadata
+from phyai.layers.attention.ar.radix.sequence import RadixSequence
+from phyai.layers.attention.enums import AttnLayout, AttnMode
+
+
+class RadixAttentionPlanner:
+    """Builds radix-prefix-reusing :class:`ARAttnMetadata` for AR attention.
+
+    Parameters
+    ----------
+    cache:
+        A built :class:`phyai_ext.radix_cache.PrefixCache` (e.g. via
+        :class:`phyai.cache.radix_cache.CacheConfig`). ``cache.atoms_per_unit``
+        must equal ``kv_pool.page_size`` so one radix unit maps to one slot.
+    kv_pool:
+        The KV slot pool the unit ids index into — used for device + slot
+        bounds. The planner never reads/writes K/V (the backend does).
+    tier:
+        Cache tier to match/allocate on. Device tier only for now.
+    """
+
+    def __init__(
+        self,
+        cache: PrefixCache,
+        kv_pool: KVCachePool,
+        *,
+        tier: Tier = Tier.DEVICE,
+    ) -> None:
+        if tier != Tier.DEVICE:
+            raise ValueError(
+                f"RadixAttentionPlanner is device-slot-only; tier must be "
+                f"Tier.DEVICE, got {tier!r}. Its unit ids are used directly as "
+                f"KVCachePool slot indices, so a non-device tier would index "
+                f"the device pool with foreign ids."
+            )
+        if cache.atoms_per_unit != kv_pool.page_size:
+            raise ValueError(
+                f"cache.atoms_per_unit ({cache.atoms_per_unit}) must equal "
+                f"kv_pool.page_size ({kv_pool.page_size}) so one radix unit "
+                f"maps to one KV pool slot."
+            )
+        if kv_pool.page_size != 1:
+            raise ValueError(
+                f"RadixAttentionPlanner currently supports page_size == 1 only "
+                f"(one token per slot); got kv_pool.page_size={kv_pool.page_size}. "
+                f"Multi-token pages are not wired through write_kv / flashinfer yet."
+            )
+        if not cache.tier_enabled(tier):
+            raise ValueError(f"cache tier {tier!r} is not enabled.")
+        if cache.total(tier) > kv_pool.num_slots:
+            raise ValueError(
+                f"cache device tier ({cache.total(tier)} units) exceeds "
+                f"kv_pool.num_slots ({kv_pool.num_slots}); cached unit ids could "
+                f"index past the pool. Size the tier <= kv_pool.num_slots."
+            )
+        self.cache = cache
+        self.kv_pool = kv_pool
+        self.tier = tier
+        self._tier_i = int(tier)
+        self.page_bytes = int(cache.page_bytes)
+        self.atoms_per_unit = int(cache.atoms_per_unit)
+        self.device = kv_pool.device
+        self.num_slots = int(kv_pool.num_slots)
+
+    # ------------------------------------------------------------------ #
+    # Plan                                                               #
+    # ------------------------------------------------------------------ #
+
+    def plan(
+        self,
+        sequences: list[RadixSequence],
+        *,
+        mode: AttnMode = AttnMode.PREFILL,
+    ) -> ARAttnMetadata:
+        """Match + allocate every sequence and assemble one ARAttnMetadata.
+
+        Mutates each :class:`RadixSequence` with its prefix/suffix slot
+        split and the radix handles (lock + suffix units) that ``commit`` /
+        ``release`` consume. Query rows are the per-sequence suffixes. Atomic:
+        if any sequence fails (capacity, validation, …), every lock and
+        allocation acquired so far in this call is rolled back before the
+        exception propagates, leaving the sequences re-plannable.
+        """
+        if not sequences:
+            raise ValueError("plan() requires at least one RadixSequence.")
+        touched: list[RadixSequence] = []
+        try:
+            return self._plan(sequences, mode, touched)
+        except BaseException:
+            for seq in touched:
+                self._rollback(seq)
+            raise
+
+    def _plan(
+        self,
+        sequences: list[RadixSequence],
+        mode: AttnMode,
+        touched: list[RadixSequence],
+    ) -> ARAttnMetadata:
+        # Validate the whole batch up front, before any side-effecting match /
+        # ensure_capacity / allocate, so a failed plan never mutates the cache:
+        # ensure_capacity can evict committed entries that _rollback cannot
+        # restore. Raises here on a released or non-page-aligned sequence.
+        for seq in sequences:
+            if seq.released:
+                raise ValueError("cannot plan a released RadixSequence.")
+            self._num_units(seq.atoms)  # raises on non-page-aligned atoms
+
+        # Pre-pass: perform every match up front so the radix tree is fully split
+        # at all needed prefix boundaries BEFORE we take any NodeRef. A later
+        # match that split an already-locked node would orphan the duplicated
+        # ref_count the C++ split copies onto the split-off suffix child
+        # (node_ref only unlocks the node->root path) and leak its units.
+        for seq in sequences:
+            if len(seq.atoms):
+                self.cache.match(seq.atoms)
+
+        suffix_lens: list[int] = []
+        total_lens: list[int] = []
+        indices_parts: list[torch.Tensor] = []
+        write_parts: list[torch.Tensor] = []
+        pos_parts: list[torch.Tensor] = []
+
+        for seq in sequences:
+            touched.append(seq)
+            num_units = self._num_units(seq.atoms)
+            prefix_units, prefix_slots = self._match_prefix(seq, num_units)
+
+            suffix_units = num_units - prefix_units
+            if suffix_units > 0:
+                self.cache.ensure_capacity(self.tier, suffix_units)
+                # Assign straight onto the sequence — keeping the OwnedUnits in a
+                # local would let an exception traceback pin it and defeat
+                # rollback's RAII free.
+                seq.suffix_units = self.cache.allocate(self.tier, suffix_units)
+                # ``ids()`` is already a host-side Python list; bounds-check it
+                # here (before building the device tensor) so we never call
+                # ``tensor.max()`` on a CUDA tensor — that forces a GPU->CPU sync
+                # on the per-step hot path.
+                suffix_ids = list(seq.suffix_units.ids())
+                if max(suffix_ids) >= self.num_slots:
+                    raise ValueError(
+                        f"allocated slot id {max(suffix_ids)} >= "
+                        f"kv_pool.num_slots={self.num_slots}; pool smaller than "
+                        f"the cache's device tier."
+                    )
+                suffix_slots = torch.as_tensor(
+                    suffix_ids, dtype=torch.int64, device=self.device
+                )
+            else:
+                suffix_slots = torch.empty(0, dtype=torch.int64, device=self.device)
+                seq.suffix_units = None
+
+            seq.prefix_len = prefix_units
+            seq.prefix_slots = prefix_slots
+            seq.suffix_slots = suffix_slots
+            seq.committed = False
+
+            s = int(suffix_slots.numel())
+            suffix_lens.append(s)
+            total_lens.append(prefix_units + s)
+            indices_parts.append(torch.cat([prefix_slots, suffix_slots]))
+            write_parts.append(suffix_slots)
+            pos_parts.append(
+                torch.arange(
+                    prefix_units,
+                    prefix_units + s,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+            )
+
+        return self._assemble(
+            len(sequences),
+            suffix_lens,
+            total_lens,
+            indices_parts,
+            write_parts,
+            pos_parts,
+            mode,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Commit / release                                                   #
+    # ------------------------------------------------------------------ #
+
+    def commit(self, sequences: list[RadixSequence]) -> None:
+        """Seed fully-new sequences into the radix tree for future reuse.
+
+        Call after the forward has scattered the suffix K/V into the pool. Only
+        sequences that were **fresh at plan time** (``prefix_len == 0``) are
+        inserted: the whole sequence is new, so the suffix units ``plan``
+        allocated are exactly the units the C++ ``insert`` needs. The decision
+        uses the plan-time ``prefix_len`` (not a commit-time re-match) so a batch
+        of fresh overlapping sequences seeds the same way regardless of order.
+
+        commit does **not** pin the seeded node. Pinning leaks units: a later
+        shorter-prefix match splits the pinned node, and ``node_ref`` only
+        unlocks the node→root path, orphaning the duplicated ref-count the C++
+        split copies onto the split-off suffix child. A committed sequence is an
+        ordinary evictable cache entry; a request's own slots are protected
+        during its active life by the prefix-reuse lock plus its held suffix
+        ``OwnedUnits``, both dropped at ``release`` (do not keep a request active
+        across other ``plan`` calls after commit).
+
+        A sequence that **reused** a cached prefix is left uncommitted (a no-op).
+        Growing an existing prefix would mean handing ``insert`` a full-length
+        unit list (it frees the matched overlap), i.e. transiently reserving
+        ``overlap`` extra slots while the prefix is still locked — which can
+        evict useful entries or fail under capacity pressure for no net gain. The
+        reuse already delivered the compute savings; ``release`` frees the
+        uncommitted suffix. Extending a cached prefix awaits a C++
+        ``insert_suffix_from_node``.
+        """
+        for seq in sequences:
+            if seq.committed or seq.suffix_units is None:
+                continue
+            if seq.prefix_len > 0:
+                continue  # reused a cached prefix at plan time — read-only
+            # Fresh at plan time: its suffix units cover the whole sequence.
+            # insert frees any prefix overlap a sibling seeded earlier in this
+            # same batch and attaches the rest, so the decision is order-free.
+            self.cache.insert(self.tier, seq.atoms, seq.suffix_units)
+            seq.suffix_units = None
+            seq.committed = True
+
+    def release(self, sequences: list[RadixSequence]) -> None:
+        """Drop prefix locks and free any uncommitted suffix units.
+
+        Idempotent. After release the matched prefix becomes evictable and
+        any planned-but-uncommitted suffix returns to the allocator.
+        """
+        for seq in sequences:
+            seq.node_ref = None  # RAII unlock
+            if not seq.committed:
+                seq.suffix_units = None  # RAII free
+            seq.released = True
+
+    def _rollback(self, seq: RadixSequence) -> None:
+        """Undo a failed plan()'s acquisitions for one sequence — drop the lock
+        and free any allocated suffix units — leaving it re-plannable (not
+        marked released)."""
+        seq.node_ref = None  # RAII unlock
+        seq.suffix_units = None  # RAII free
+        seq.prefix_len = 0
+        seq.prefix_slots = None
+        seq.suffix_slots = None
+        seq.committed = False
+
+    # ------------------------------------------------------------------ #
+    # Helpers                                                            #
+    # ------------------------------------------------------------------ #
+
+    def _num_units(self, atoms: bytes) -> int:
+        n = len(atoms)
+        if n % self.page_bytes != 0:
+            raise ValueError(
+                f"atoms length {n} is not a multiple of page_bytes="
+                f"{self.page_bytes}; page-align before planning."
+            )
+        return n // self.page_bytes
+
+    def _match_prefix(self, seq: RadixSequence, num_units: int):
+        """Match seq's cached prefix; lock it onto ``seq.node_ref`` (no local,
+        so rollback can free it). Returns ``(prefix_units, prefix_slots)``."""
+        empty = torch.empty(0, dtype=torch.int64, device=self.device)
+        seq.node_ref = None
+        if num_units == 0:
+            return 0, empty
+        mr = self.cache.match(seq.atoms)
+        prefix_units = min(
+            int(mr.matched_atoms[self._tier_i]) // self.atoms_per_unit, num_units
+        )
+        if prefix_units == 0:
+            return 0, empty
+        node = int(mr.last_node[self._tier_i])
+        seq.node_ref = self.cache.lock(self.tier, node)
+        slots = torch.from_dlpack(self.cache.collect_units(node, self.tier)).to(
+            device=self.device, dtype=torch.int64
+        )
+        if int(slots.numel()) != prefix_units:
+            raise RuntimeError(
+                f"collect_units returned {int(slots.numel())} slots but match "
+                f"reported {prefix_units} prefix units."
+            )
+        return prefix_units, slots
+
+    def _assemble(
+        self, B, suffix_lens, total_lens, indices_parts, write_parts, pos_parts, mode
+    ):
+        suffix_t = torch.tensor(suffix_lens, dtype=torch.int32, device=self.device)
+        total_t = torch.tensor(total_lens, dtype=torch.int32, device=self.device)
+        cu_seqlens_q = torch.zeros(B + 1, dtype=torch.int32, device=self.device)
+        cu_seqlens_q[1:] = torch.cumsum(suffix_t, 0)
+        paged_kv_indptr = torch.zeros(B + 1, dtype=torch.int32, device=self.device)
+        paged_kv_indptr[1:] = torch.cumsum(total_t, 0)
+        return ARAttnMetadata(
+            mode=mode,
+            layout=AttnLayout.RAGGED_3D,
+            batch_size=B,
+            num_query_tokens=int(sum(suffix_lens)),
+            cu_seqlens_q=cu_seqlens_q,
+            paged_kv_indptr=paged_kv_indptr,
+            paged_kv_indices=torch.cat(indices_parts).to(torch.int32),
+            paged_kv_last_page_len=(total_t > 0).to(torch.int32),
+            write_indices=torch.cat(write_parts).to(torch.int64),
+            position_ids=torch.cat(pos_parts).to(torch.int32),
+        )
+
+
+__all__ = ["RadixAttentionPlanner"]

--- a/phyai/src/phyai/layers/attention/ar/radix/sequence.py
+++ b/phyai/src/phyai/layers/attention/ar/radix/sequence.py
@@ -1,0 +1,42 @@
+"""Per-request planning state for radix-cache-backed AR attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass
+class RadixSequence:
+    """Mutable per-request state for one planned AR attention step.
+
+    Carries the request's pre-encoded, page-aligned ``atoms`` in; the
+    :class:`~phyai.layers.attention.ar.radix.planner.RadixAttentionPlanner`
+    fills the prefix/suffix slot split and the radix-cache handles (the
+    prefix lock and the suffix units) that must outlive the forward. Treat
+    every field other than ``atoms`` as planner-owned.
+    """
+
+    atoms: bytes
+    prefix_len: int = 0
+    prefix_slots: torch.Tensor | None = None
+    suffix_slots: torch.Tensor | None = None
+    node_ref: Any | None = None  # phyai_ext.radix_cache.NodeRef | None
+    suffix_units: Any | None = None  # phyai_ext.radix_cache.OwnedUnits | None
+    committed: bool = False
+    released: bool = False
+
+    @property
+    def suffix_len(self) -> int:
+        """Newly allocated (written) slot count; 0 until plan()."""
+        return 0 if self.suffix_slots is None else int(self.suffix_slots.numel())
+
+    @property
+    def total_len(self) -> int:
+        """prefix + suffix slot count; valid after plan()."""
+        return self.prefix_len + self.suffix_len
+
+
+__all__ = ["RadixSequence"]

--- a/phyai/tests/layers/attention/ar/test_radix_flashinfer.py
+++ b/phyai/tests/layers/attention/ar/test_radix_flashinfer.py
@@ -1,0 +1,119 @@
+"""CUDA end-to-end: radix prefix reuse through ARAttention(flashinfer)
+matches a full eager recompute. Gated on CUDA + flashinfer-python."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+import torch
+
+from phyai_ext.radix_cache import PrefixCache
+
+from phyai.cache import KVCachePool
+from phyai.layers.attention import (
+    ARAttention,
+    ARAttnCtx,
+    AttnLayout,
+    AttnMode,
+)
+from phyai.layers.attention.ar import FlashInferARBackend
+from phyai.layers.attention.ar.radix import RadixAttentionPlanner, RadixSequence
+from phyai.layers.attention.common import eager_attn, repeat_kv
+
+
+def _has_flashinfer() -> bool:
+    # flashinfer initialises CUDA eagerly on import; on a broken / misconfigured
+    # CUDA setup that raises a RuntimeError (not just ImportError). Treat ANY
+    # failure as "unavailable" so this test skips instead of crashing collection.
+    try:
+        import flashinfer.prefill  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and _has_flashinfer()),
+    reason="radix flashinfer e2e requires CUDA + flashinfer-python.",
+)
+
+
+def _atoms(tokens):
+    return struct.pack(f"{len(tokens)}i", *tokens)
+
+
+def _eager_full_causal(q, k, v, H, H_kv, scale):
+    qi = q.transpose(0, 1).unsqueeze(0)
+    ki = repeat_kv(k.transpose(0, 1).unsqueeze(0), H, H_kv)
+    vi = repeat_kv(v.transpose(0, 1).unsqueeze(0), H, H_kv)
+    o = eager_attn(
+        qi, ki, vi, scale=scale, causal=True, sliding_window=None, logits_soft_cap=None
+    )
+    return o.squeeze(0).transpose(0, 1)
+
+
+def test_radix_flashinfer_e2e_prefix_reuse_matches_eager():
+    torch.manual_seed(0)
+    H, H_kv, D = 4, 2, 64
+    N, P = 6, 3
+    dev = torch.device("cuda")
+    q = torch.randn(N, H, D, dtype=torch.float16, device=dev)
+    k = torch.randn(N, H_kv, D, dtype=torch.float16, device=dev)
+    v = torch.randn(N, H_kv, D, dtype=torch.float16, device=dev)
+    scale = 1.0 / D**0.5
+
+    # Reference: fp32 eager full causal recompute, suffix rows.
+    ref_suffix = _eager_full_causal(q.float(), k.float(), v.float(), H, H_kv, scale)[P:]
+
+    cache = PrefixCache(atom_bytes=4, atoms_per_unit=1, device_total_units=64)
+    pool = KVCachePool(
+        num_layers=1,
+        num_slots=64,
+        num_kv_heads=H_kv,
+        head_dim=D,
+        dtype=torch.float16,
+        device=dev,
+    )
+    planner = RadixAttentionPlanner(cache, pool)
+    layer = ARAttention(
+        num_heads=H,
+        head_dim=D,
+        layer_id=0,
+        num_kv_heads=H_kv,
+        causal=True,
+        backend="flashinfer",
+    )
+    backend = FlashInferARBackend()
+    backend.init_cuda_graph_state(
+        max_batch_size=1,
+        max_num_tokens=N,
+        max_paged_kv_indices=N,
+        device=dev,
+        params_dtype=torch.float16,
+        layer_proto=layer,
+    )
+
+    def run(meta, qsub, ksub, vsub):
+        plan = backend.init_forward_metadata(meta)
+        ctx = ARAttnCtx(
+            backend=backend,
+            plan=plan,
+            mode=AttnMode.PREFILL,
+            layout=AttnLayout.RAGGED_3D,
+            kv_pool=pool,
+            write_indices=meta.write_indices,
+        )
+        return layer(qsub, ksub, vsub, ctx)
+
+    toks = [10, 11, 12, 20, 21, 22]
+    a = RadixSequence(_atoms(toks[:P]))
+    run(planner.plan([a]), q[:P], k[:P], v[:P])
+    planner.commit([a])
+    c = RadixSequence(_atoms(toks))
+    meta_c = planner.plan([c])
+    assert c.prefix_len == P
+    out = run(meta_c, q[P:], k[P:], v[P:])
+
+    assert torch.allclose(out.float().cpu(), ref_suffix.cpu(), atol=2e-2, rtol=2e-2)

--- a/phyai/tests/layers/attention/ar/test_radix_gather_e2e.py
+++ b/phyai/tests/layers/attention/ar/test_radix_gather_e2e.py
@@ -1,0 +1,76 @@
+"""CPU end-to-end: radix prefix reuse reassembles the exact logical KV.
+
+The AR stack is flashinfer-only (GPU) after upstream removed the eager
+backend, so full attention numerics are covered by the CUDA-gated
+``test_radix_flashinfer.py``. This CPU test guards the part the planner
+actually owns and that CI (CPU) can exercise without a kernel: after a
+shared prefix is committed and a decoy pushes the reuse suffix off the
+prefix's contiguous slot range, the gathered ``[prefix ++ suffix]`` KV
+must equal a full recompute's KV — i.e. the planner's ``paged_kv_indices``
+and ``write_indices`` round-trip through the pool correctly.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import torch
+
+from phyai_ext.radix_cache import PrefixCache
+
+from phyai.cache import KVCachePool
+from phyai.layers.attention.ar.radix import RadixAttentionPlanner, RadixSequence
+
+
+def _atoms(tokens):
+    return struct.pack(f"{len(tokens)}i", *tokens)
+
+
+def test_radix_reuse_gathers_exact_prefix_plus_suffix():
+    torch.manual_seed(0)
+    H_kv, D = 2, 8
+    N, P = 6, 3
+    k = torch.randn(N, H_kv, D)
+    v = torch.randn(N, H_kv, D)
+
+    cache = PrefixCache(atom_bytes=4, atoms_per_unit=1, device_total_units=64)
+    pool = KVCachePool(
+        num_layers=1,
+        num_slots=64,
+        num_kv_heads=H_kv,
+        head_dim=D,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+    planner = RadixAttentionPlanner(cache, pool)
+
+    toks = [10, 11, 12, 20, 21, 22]
+
+    # Seed the shared prefix [10,11,12], writing K/V[0:P] at its slots.
+    a = RadixSequence(_atoms(toks[:P]))
+    meta_a = planner.plan([a])
+    pool.write_kv(0, meta_a.write_indices, k[:P], v[:P])
+    planner.commit([a])
+
+    # Decoy: commit an unrelated sequence so its slots sit between the prefix's
+    # range and the reuse suffix's range, forcing non-contiguous indices.
+    d = RadixSequence(_atoms([55, 66]))
+    meta_d = planner.plan([d])
+    pool.write_kv(
+        0, meta_d.write_indices, torch.randn(2, H_kv, D), torch.randn(2, H_kv, D)
+    )
+    planner.commit([d])
+
+    # Reuse: query = suffix only; KV = cached prefix + freshly written suffix.
+    c = RadixSequence(_atoms(toks))
+    meta_c = planner.plan([c])
+    assert c.prefix_len == P
+    assert meta_c.paged_kv_indices.tolist() == [1, 2, 3, 6, 7, 8]  # non-contiguous
+    pool.write_kv(0, meta_c.write_indices, k[P:], v[P:])
+
+    gathered_k, gathered_v = pool.gather_kv(0, meta_c.paged_kv_indices)
+
+    # The reuse gather must reproduce the whole sequence's KV bit-for-bit:
+    # prefix rows come from the seed call's cache, suffix rows from this call.
+    assert torch.equal(gathered_k, k)
+    assert torch.equal(gathered_v, v)

--- a/phyai/tests/layers/attention/ar/test_radix_planner.py
+++ b/phyai/tests/layers/attention/ar/test_radix_planner.py
@@ -1,0 +1,364 @@
+"""CPU planner-logic tests for the radix → AR attention bridge."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+import torch
+
+from phyai_ext.radix_cache import CacheCapacityError, PrefixCache, Tier
+
+from phyai.cache import KVCachePool
+from phyai.layers.attention.ar.radix import RadixAttentionPlanner, RadixSequence
+
+
+def _atoms(tokens):
+    return struct.pack(f"{len(tokens)}i", *tokens)
+
+
+def _build(num_slots: int = 64, total_units: int = 64):
+    cache = PrefixCache(atom_bytes=4, atoms_per_unit=1, device_total_units=total_units)
+    pool = KVCachePool(
+        num_layers=1,
+        num_slots=num_slots,
+        num_kv_heads=2,
+        head_dim=4,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+    return cache, pool, RadixAttentionPlanner(cache, pool)
+
+
+def test_sequence_defaults():
+    s = RadixSequence(atoms=_atoms([7]))
+    assert s.prefix_len == 0
+    assert s.suffix_len == 0
+    assert s.total_len == 0
+    assert not s.committed and not s.released
+
+
+def test_construction_rejects_unit_size_mismatch():
+    cache = PrefixCache(atom_bytes=4, atoms_per_unit=2, device_total_units=64)
+    pool = KVCachePool(
+        num_layers=1,
+        num_slots=64,
+        num_kv_heads=2,
+        head_dim=4,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )  # page_size=1 != atoms_per_unit=2
+    with pytest.raises(ValueError, match="atoms_per_unit"):
+        RadixAttentionPlanner(cache, pool)
+
+
+def test_construction_rejects_non_device_tier():
+    # Even with the host tier enabled, the device-slot-only planner must reject
+    # it: host unit ids are not device-pool slots.
+    cache = PrefixCache(
+        atom_bytes=4, atoms_per_unit=1, device_total_units=64, host_total_units=64
+    )
+    pool = KVCachePool(
+        num_layers=1,
+        num_slots=64,
+        num_kv_heads=2,
+        head_dim=4,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+    with pytest.raises(ValueError, match="Tier.DEVICE"):
+        RadixAttentionPlanner(cache, pool, tier=Tier.HOST)
+
+
+def test_construction_rejects_multi_token_page():
+    # Multi-token pages aren't supported end-to-end (write_kv / flashinfer are
+    # page_size=1 only; the metadata counts radix units).
+    cache = PrefixCache(atom_bytes=4, atoms_per_unit=2, device_total_units=64)
+    pool = KVCachePool(
+        num_layers=1,
+        num_slots=64,
+        num_kv_heads=2,
+        head_dim=4,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        page_size=2,
+    )
+    with pytest.raises(ValueError, match="page_size == 1"):
+        RadixAttentionPlanner(cache, pool)
+
+
+def test_construction_rejects_cache_larger_than_pool():
+    # A cache whose device tier can hand out more unit ids than the pool has
+    # slots would produce out-of-bounds prefix/suffix slot indices.
+    cache = PrefixCache(atom_bytes=4, atoms_per_unit=1, device_total_units=128)
+    pool = KVCachePool(
+        num_layers=1,
+        num_slots=64,
+        num_kv_heads=2,
+        head_dim=4,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+    with pytest.raises(ValueError, match="num_slots"):
+        RadixAttentionPlanner(cache, pool)
+
+
+def test_plan_fresh_sequence_allocates_full_suffix():
+    cache, pool, planner = _build()
+    seq = RadixSequence(_atoms([10, 11, 12]))
+    meta = planner.plan([seq])
+    assert seq.prefix_len == 0
+    assert seq.suffix_slots.tolist() == [1, 2, 3]
+    assert seq.node_ref is None
+    assert meta.batch_size == 1
+    assert meta.num_query_tokens == 3
+    assert meta.cu_seqlens_q.tolist() == [0, 3]
+    assert meta.paged_kv_indptr.tolist() == [0, 3]
+    assert meta.paged_kv_indices.tolist() == [1, 2, 3]
+    assert meta.paged_kv_indices.dtype == torch.int32
+    assert meta.write_indices.tolist() == [1, 2, 3]
+    assert meta.write_indices.dtype == torch.int64
+    assert meta.paged_kv_last_page_len.tolist() == [1]
+    assert meta.position_ids.tolist() == [0, 1, 2]
+
+
+def test_plan_rejects_unaligned_atoms():
+    cache, pool, planner = _build()
+    with pytest.raises(ValueError, match="page_bytes"):
+        planner.plan([RadixSequence(b"abcde")])  # 5 bytes, page_bytes=4
+
+
+def test_plan_reuse_shares_prefix_slots_non_contiguous():
+    cache, pool, planner = _build()
+    a = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([a])
+    planner.commit([a])  # tree: [10,11,12] -> [1,2,3]
+    d = RadixSequence(_atoms([55, 66]))  # decoy consumes [4,5]
+    planner.plan([d])
+    planner.commit([d])
+    c = RadixSequence(_atoms([10, 11, 12, 77, 88]))
+    meta = planner.plan([c])
+    assert c.prefix_len == 3
+    assert c.prefix_slots.tolist() == [1, 2, 3]
+    assert c.suffix_slots.tolist() == [6, 7]
+    assert meta.paged_kv_indices.tolist() == [1, 2, 3, 6, 7]  # gap 3->6
+    assert meta.cu_seqlens_q.tolist() == [0, 2]
+    assert meta.paged_kv_indptr.tolist() == [0, 5]
+    assert meta.write_indices.tolist() == [6, 7]
+    assert meta.position_ids.tolist() == [3, 4]
+    assert c.node_ref is not None
+
+
+def test_plan_fully_cached_sequence_has_no_query_rows():
+    cache, pool, planner = _build()
+    a = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([a])
+    planner.commit([a])
+    b = RadixSequence(_atoms([10, 11, 12]))  # identical -> fully cached
+    meta = planner.plan([b])
+    assert b.prefix_len == 3
+    assert b.suffix_len == 0
+    assert meta.num_query_tokens == 0
+    assert meta.cu_seqlens_q.tolist() == [0, 0]
+    assert meta.paged_kv_indices.tolist() == [1, 2, 3]
+    assert meta.write_indices.numel() == 0
+
+
+def test_commit_seeds_fresh_sequence():
+    cache, pool, planner = _build()
+    a = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([a])
+    planner.commit([a])
+    assert a.committed and a.suffix_units is None
+    mr = cache.match(_atoms([10, 11, 12]))
+    assert int(mr.matched_atoms[int(Tier.DEVICE)]) == 3
+
+
+def test_commit_skips_reused_sequence_no_growth_no_alloc():
+    """commit() seeds only fully-new sequences. A reused (prefix>0) sequence is
+    a no-op — no transient overlap allocation (which could evict/fail) and no
+    tree growth; release() frees its written suffix."""
+    cache, pool, planner = _build()
+    a = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([a])
+    planner.commit([a])
+    c = RadixSequence(_atoms([10, 11, 12, 77, 88]))
+    planner.plan([c])  # prefix [1,2,3], suffix [4,5]
+    avail_after_plan = cache.available(Tier.DEVICE)
+    planner.commit([c])  # reuse -> no-op
+    assert not c.committed
+    assert cache.available(Tier.DEVICE) == avail_after_plan  # no transient alloc
+    mr = cache.match(_atoms([10, 11, 12, 77, 88]))
+    assert int(mr.matched_atoms[int(Tier.DEVICE)]) == 3  # tree not grown
+    planner.release([c])
+    assert c.suffix_units is None
+
+
+def test_commit_seeds_fresh_overlapping_sequence_regardless_of_order():
+    """Two fresh sequences where one is a prefix of the other: committing the
+    shorter first must NOT cause the longer (planned fresh) one to be skipped.
+    The seed decision uses plan-time prefix_len, not a commit-time re-match."""
+    cache, pool, planner = _build()
+    ab = RadixSequence(_atoms([1, 2]))
+    abc = RadixSequence(_atoms([1, 2, 3]))
+    planner.plan([ab, abc])  # cache empty at plan -> both prefix_len == 0
+    assert ab.prefix_len == 0 and abc.prefix_len == 0
+    planner.commit([ab, abc])  # commit ab first, then abc
+    assert ab.committed and abc.committed
+    assert int(cache.match(_atoms([1, 2, 3])).matched_atoms[int(Tier.DEVICE)]) == 3
+    planner.release([ab, abc])
+
+
+def test_commit_does_not_pin_seeded_node():
+    """commit() must NOT pin the seeded node — pinning leaks units when a later
+    shorter-prefix match splits it. A committed sequence is an evictable cache
+    entry: a competing request under capacity pressure reuses its slots."""
+    cache, pool, planner = _build(num_slots=8, total_units=4)  # ids 1..3 usable
+    a = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([a])
+    planner.commit([a])
+    assert a.committed and a.node_ref is None  # not pinned
+    # Cache is full (3/3) but a is unpinned -> a competitor evicts it and fits.
+    b = RadixSequence(_atoms([20, 21, 22]))
+    meta_b = planner.plan([b])
+    assert meta_b.write_indices.numel() == 3
+    planner.release([a])
+    planner.release([b])
+
+
+def test_release_frees_lock_and_uncommitted_units():
+    cache, pool, planner = _build()
+    a = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([a])
+    planner.commit([a])
+    avail_before = cache.available(Tier.DEVICE)
+    c = RadixSequence(_atoms([10, 11, 12, 77, 88]))
+    planner.plan([c])  # locks prefix, allocates 2 suffix
+    assert c.node_ref is not None
+    assert cache.available(Tier.DEVICE) == avail_before - 2
+    planner.release([c])  # not committed -> free suffix + drop lock
+    assert c.node_ref is None
+    assert c.suffix_units is None
+    assert c.released
+    assert cache.available(Tier.DEVICE) == avail_before
+
+
+def test_plan_raises_capacity_error_when_locked_and_full():
+    cache, pool, planner = _build(num_slots=8, total_units=4)  # ids 1..3 usable
+    a = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([a])
+    planner.commit([a])  # avail 0, tree=[10,11,12]->[1,2,3]
+    c = RadixSequence(_atoms([10, 11, 12, 20]))  # reuse + 1 new, but no free slot
+    with pytest.raises(CacheCapacityError):
+        planner.plan([c])
+
+
+def test_plan_rolls_back_locks_and_units_on_failure():
+    """A mid-batch plan() failure must release every lock and free every unit
+    acquired so far, leaving touched sequences re-plannable (atomic plan)."""
+    cache, pool, planner = _build(num_slots=8, total_units=6)  # ids 1..5 usable
+    a = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([a])
+    planner.commit([a])  # seed [1,2,3], avail 2
+    avail0 = cache.available(Tier.DEVICE)
+    seq_c = RadixSequence(_atoms([10, 11, 12, 77]))  # reuse: locks [1,2,3], allocs 1
+    seq_d = RadixSequence(_atoms([20, 21, 22, 23]))  # fresh: needs 4 > free -> fails
+    with pytest.raises(CacheCapacityError):
+        planner.plan([seq_c, seq_d])
+    assert seq_c.node_ref is None  # lock rolled back
+    assert seq_c.suffix_units is None  # units freed
+    assert not seq_c.released  # still re-plannable
+    assert cache.available(Tier.DEVICE) == avail0  # capacity restored
+
+
+def test_bridge_reexported_from_ar_package():
+    import phyai.layers.attention.ar as ar
+
+    assert ar.RadixAttentionPlanner is RadixAttentionPlanner
+    assert ar.RadixSequence is RadixSequence
+
+
+def test_ar_import_does_not_pull_radix_extension():
+    """phyai-ext is an optional extra; importing the base AR package must not
+    import phyai_ext, so non-[ext] installs can still use the attention
+    layers/backends. The radix bridge is re-exported lazily."""
+    import subprocess
+    import sys
+
+    code = (
+        "import sys\n"
+        "import phyai.layers.attention.ar\n"
+        "assert 'phyai_ext' not in sys.modules, 'phyai_ext imported eagerly'\n"
+        "assert 'phyai.layers.attention.ar.radix' not in sys.modules, 'radix eager'\n"
+        "from phyai.layers.attention.ar import RadixAttentionPlanner\n"
+        "assert 'phyai_ext' in sys.modules, 'lazy access should load phyai_ext'\n"
+        "print('LAZY_OK')\n"
+    )
+    res = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+    assert "LAZY_OK" in res.stdout
+
+
+def test_star_import_does_not_pull_radix_extension():
+    """`from ...ar import *` must not eagerly resolve the lazy radix names —
+    that would call __getattr__, import phyai_ext, and break a base install
+    without the optional [ext] extra. So the radix names stay out of __all__."""
+    import subprocess
+    import sys
+
+    code = (
+        "import sys\n"
+        "from phyai.layers.attention.ar import *  # noqa: F401,F403\n"
+        "assert 'phyai_ext' not in sys.modules, 'star-import pulled phyai_ext'\n"
+        "assert 'phyai.layers.attention.ar.radix' not in sys.modules\n"
+        "print('STAR_OK')\n"
+    )
+    res = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+    assert "STAR_OK" in res.stdout
+
+
+def test_no_leak_when_batch_reuses_nested_prefixes():
+    """A batch reusing a committed prefix to different depths must not leak
+    units. Locking a node that a sibling's shorter match later splits would
+    orphan the split-off child's duplicated ref_count; plan() pre-splits the
+    tree before taking any lock to avoid that."""
+    cache, pool, planner = _build(num_slots=16, total_units=16)
+    avail_empty = cache.available(Tier.DEVICE)
+    seed = RadixSequence(_atoms([1, 2, 3, 4, 5]))
+    planner.plan([seed])
+    planner.commit([seed])
+    planner.release([seed])
+    # Batch: x reuses the full [1..5]; y reuses only [1,2,3] (a shorter prefix).
+    x = RadixSequence(_atoms([1, 2, 3, 4, 5, 6]))
+    y = RadixSequence(_atoms([1, 2, 3, 9]))
+    planner.plan([x, y])
+    assert x.prefix_len == 5 and y.prefix_len == 3
+    planner.release([x, y])
+    # Drain fully: a true leak (ref_count > 0) can never be reclaimed.
+    prev = -1
+    while cache.available(Tier.DEVICE) != prev:
+        prev = cache.available(Tier.DEVICE)
+        try:
+            cache.ensure_capacity(Tier.DEVICE, cache.total(Tier.DEVICE))
+        except CacheCapacityError:
+            break
+    assert cache.available(Tier.DEVICE) == avail_empty
+
+
+def test_failed_plan_does_not_evict_committed_entries():
+    """An invalid sequence later in a batch makes plan() raise WITHOUT having
+    evicted committed entries: validation runs before any ensure_capacity."""
+    cache, pool, planner = _build(num_slots=4, total_units=4)  # ids 1..3 usable
+    c = RadixSequence(_atoms([10, 11, 12]))
+    planner.plan([c])
+    planner.commit([c])
+    planner.release([c])  # C is a committed, evictable cache entry (avail 0)
+    assert int(cache.match(_atoms([10, 11, 12])).matched_atoms[int(Tier.DEVICE)]) == 3
+    good = RadixSequence(_atoms([20, 21, 22]))  # valid; would need to evict C
+    bad = RadixSequence(b"abcde")  # unaligned -> raises
+    with pytest.raises(ValueError, match="page_bytes"):
+        planner.plan([good, bad])
+    # C must survive: the failed plan did no eviction / allocation.
+    assert int(cache.match(_atoms([10, 11, 12])).matched_atoms[int(Tier.DEVICE)]) == 3
+    assert not good.committed and good.suffix_units is None


### PR DESCRIPTION
## Summary
Wires the existing radix prefix cache (`phyai_ext.radix_cache.PrefixCache`) into the AR (LM-side) attention path so requests reuse the KV of a shared prompt prefix and only attend over the new (suffix) tokens — the standard RadixAttention speedup. Model- and encoding-agnostic; pi0.5's `StaticCache` path is untouched. Foundation for the upcoming cosmos adaptation.

## What's in it
New components under `phyai/layers/attention/ar/radix/`:
- **RadixSequence**: Per-request state (pre-encoded `atoms` in; prefix/suffix slot split + radix handles out).
- **RadixAttentionPlanner**: The bridge over `PrefixCache`, with a 3-call lifecycle.
  - `plan(seqs) -> ARAttnMetadata`: Matches cached prefix → reuses those slots → allocates suffix-only → builds `cu_seqlens_q` / `paged_kv_indptr` / `paged_kv_indices` / `write_indices` / `position_ids`, with query = suffix tokens only.
  - `commit(seqs)`: Seeds a fresh sequence into the tree for future reuse.
  - `release(seqs)`: Drops the reused-prefix lock and frees the uncommitted suffix.
- **Purely additive — no attention backend modified**: on current main the AR stack is flashinfer-only, and flashinfer's paged prefill natively consumes the non-contiguous `paged_kv_indices` radix produces, so the planner just feeds it. 
- **Lazy re-exporting**: The bridge is lazily re-exported from `phyai.layers.attention.ar`, keeping the optional `phyai-ext` extra off the base attention import.

## Contract
Prefill-with-prefix: the caller feeds Q/K/V for the suffix tokens only; the flashinfer paged backend scatters the new K/V at `write_indices` and reads `prefix_slots ++ suffix_slots`. Causal masking for `q_len < kv_len` is handled by flashinfer's paged prefill — the suffix query is aligned to the tail of the KV via `qo_indptr` vs `paged_kv_indptr`.

## Scope / non-goals
- Device tier only and `page_size == 1` (both enforced at construction).
- Decode loop / incremental cache growth, multi-token pages, host/disk tiers: out of scope .

## Tests
- `tests/layers/attention/ar/test_radix_planner.py` — 21 CPU planner-logic tests (exact-tensor metadata, prefix reuse + non-contiguous indices, commit/release, `plan()` rollback, no-leak under nested reuse, capacity/validation errors, lazy/star-import safety).
- `test_radix_gather_e2e.py` — CPU, backend-free: after seed → commit → decoy → reuse, the gathered `[cached prefix ++ fresh suffix]` equals the full sequence's KV (asserts the exact non-contiguous `paged_kv_indices`). Keeps CI numeric coverage without a kernel.
- `test_radix_flashinfer.py` — CUDA paged e2e (auto-skips without CUDA + flashinfer).
- `tests/layers/attention/` suite green on CPU: **54 passed, 14 skipped** (skips are the CUDA-gated flashinfer / vgpu / norm-backend tests).

## Notes
Hardened across review rounds: device-only tier, lazy/star-import safety, `plan()` atomicity (rollback + validate-before-side-effects), order-independent commit, the KV-pool bounds check, and the NodeRef split-leak fix (commit doesn't pin; `plan()` pre-splits the tree before locking).