### PR TITLE
feat(phyai): WALL OSS Support

### DIFF
--- a/examples/run_walloss_flow.py
+++ b/examples/run_walloss_flow.py
@@ -1,0 +1,185 @@
+"""Run WALL-OSS-FLOW inference end-to-end through the PhyAI engine plugin path.
+
+This example spins up the ``walloss`` plugin behind ``Engine``, feeds a
+dummy validate request that mirrors the existing wall-x FLOW fake inference
+path, and reports logits shape plus per-step latency.
+
+The dummy inputs are not semantically meaningful. The script is intended to
+verify Engine/plugin wiring and provide a small reproducible smoke benchmark.
+
+Run::
+
+    python examples/run_walloss_flow.py --checkpoint /path/to/wall-oss-flow
+
+On A40/sm86 hosts, use a PhyAI version that includes the upstream sm86
+Linear-kernel registration fix, such as nightly ``0.1.1.dev20260601`` or newer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+from pathlib import Path
+
+import torch
+
+from phyai.engine import Engine, EngineArgs
+from phyai.engine_config import DeviceConfig, EngineConfig, RuntimeConfig
+from phyai.models.walloss.configuration_walloss import WallOSSFlowConfig
+from phyai.models.walloss.main_walloss import WallOSSArgs
+from phyai.models.walloss.scheduler_ws1_walloss import WallOSSFlowRequest
+
+
+def make_dummy_request(
+    *,
+    batch_size: int,
+    seq_len: int,
+    plugin_cfg: WallOSSFlowConfig,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> WallOSSFlowRequest:
+    """Build a placeholder WALL-OSS-FLOW validate request."""
+    position_ids = torch.arange(seq_len, dtype=torch.long, device=device)
+    position_ids = position_ids.unsqueeze(0).expand(batch_size, -1).contiguous()
+
+    return WallOSSFlowRequest(
+        input_ids=torch.zeros(batch_size, seq_len, dtype=torch.long, device=device),
+        attention_mask=torch.ones(batch_size, seq_len, dtype=torch.long, device=device),
+        moe_token_types=torch.zeros(batch_size, seq_len, dtype=torch.long, device=device),
+        position_ids=position_ids,
+        proprioception=torch.zeros(
+            batch_size, 1, plugin_cfg.proprio_dim, dtype=dtype, device=device
+        ),
+        agent_pos_mask=torch.ones(
+            batch_size, 1, plugin_cfg.proprio_dim, dtype=dtype, device=device
+        ),
+        dof_mask=torch.ones(
+            batch_size,
+            plugin_cfg.action_horizon,
+            plugin_cfg.action_dim,
+            dtype=dtype,
+            device=device,
+        ),
+        dataset_names=plugin_cfg.dataset_name,
+    )
+
+
+def benchmark(
+    engine: Engine,
+    request: WallOSSFlowRequest,
+    *,
+    n_warmup: int,
+    n_timed: int,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Warm up and time ``engine.step`` calls; return the last logits and stats."""
+    outputs = None
+    for _ in range(n_warmup):
+        outputs = engine.step(request)
+    torch.cuda.synchronize()
+
+    times_ms: list[float] = []
+    for _ in range(n_timed):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        outputs = engine.step(request)
+        end.record()
+        torch.cuda.synchronize()
+        times_ms.append(start.elapsed_time(end))
+
+    if outputs is None:
+        raise RuntimeError("benchmark did not run any engine.step call.")
+
+    logits = outputs.logits
+    return logits, {
+        "mean": statistics.fmean(times_ms),
+        "median": statistics.median(times_ms),
+        "stdev": statistics.stdev(times_ms) if len(times_ms) > 1 else 0.0,
+        "min": min(times_ms),
+        "max": max(times_ms),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        required=True,
+        help="Path to the WALL-OSS-FLOW checkpoint folder.",
+    )
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--seq-len", type=int, default=50)
+    parser.add_argument("--n-warmup", type=int, default=1)
+    parser.add_argument("--n-timed", type=int, default=3)
+    parser.add_argument(
+        "--use-cuda-graph",
+        action="store_true",
+        help="Enable CUDA graph in RuntimeConfig. Disabled by default for smoke tests.",
+    )
+    args = parser.parse_args()
+
+    if not args.checkpoint.is_dir():
+        raise NotADirectoryError(f"--checkpoint must be a directory: {args.checkpoint}")
+    if args.batch_size <= 0:
+        raise ValueError(f"--batch-size must be positive, got {args.batch_size}.")
+    if args.seq_len <= 0:
+        raise ValueError(f"--seq-len must be positive, got {args.seq_len}.")
+    if args.n_timed <= 0:
+        raise ValueError(f"--n-timed must be positive, got {args.n_timed}.")
+
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    plugin_cfg = WallOSSFlowConfig.from_checkpoint(args.checkpoint)
+
+    engine = Engine(
+        EngineArgs(
+            plugin="walloss",
+            plugin_args=WallOSSArgs(
+                checkpoint_dir=args.checkpoint,
+                max_batch_size=args.batch_size,
+                action_horizon=plugin_cfg.action_horizon,
+                dataset_name=plugin_cfg.dataset_name,
+            ),
+            config=EngineConfig(
+                device=DeviceConfig(target="cuda", params_dtype=dtype),
+                runtime=RuntimeConfig(use_cuda_graph=args.use_cuda_graph),
+            ),
+        )
+    )
+
+    try:
+        request = make_dummy_request(
+            batch_size=args.batch_size,
+            seq_len=args.seq_len,
+            plugin_cfg=plugin_cfg,
+            device=device,
+            dtype=dtype,
+        )
+        logits, stats = benchmark(
+            engine, request, n_warmup=args.n_warmup, n_timed=args.n_timed
+        )
+
+        print(f"config            : {plugin_cfg}")
+        print(f"logits shape      : {tuple(logits.shape)}")
+        print(f"logits dtype      : {logits.dtype}")
+        print(f"logits device     : {logits.device}")
+        print(f"has_nan           : {torch.isnan(logits).any().item()}")
+        print(f"has_inf           : {torch.isinf(logits).any().item()}")
+        print(
+            f"step latency      : mean={stats['mean']:.2f} ms  "
+            f"median={stats['median']:.2f} ms  std={stats['stdev']:.2f} ms  "
+            f"min={stats['min']:.2f} ms  max={stats['max']:.2f} ms  "
+            f"(n_warmup={args.n_warmup}, n_timed={args.n_timed})"
+        )
+    finally:
+        engine.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_walloss_flow_predict_dryrun.py
+++ b/examples/run_walloss_flow_predict_dryrun.py
@@ -1,0 +1,253 @@
+"""Run WALL-OSS-FLOW policy predict dry-run through the PhyAI engine plugin path.
+
+This example keeps the real processor / prepare_batch logic outside the core
+runner and scheduler. It builds a dummy observation, converts it with wall-x's
+official prepare_batch helper, then sends a WallOSSFlowPredictRequest through
+Engine(plugin="walloss").
+
+Run::
+
+    PYTHONPATH=/phyai_workspace/src/wall-x:$PYTHONPATH \
+    python examples/run_walloss_flow_predict_dryrun.py \
+      --checkpoint /data/share/x-square-robot/wall-oss-flow \
+      --wall-x-root /phyai_workspace/src/wall-x
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import statistics
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import AutoProcessor
+
+from phyai.engine import Engine, EngineArgs
+from phyai.engine_config import DeviceConfig, EngineConfig, RuntimeConfig
+from phyai.models.walloss.configuration_walloss import WallOSSFlowConfig
+from phyai.models.walloss.main_walloss import WallOSSArgs
+from phyai.models.walloss.scheduler_ws1_walloss import WallOSSFlowPredictRequest
+
+
+def _load_prepare_batch(wall_x_root: Path):
+    """Load wall_x/serving/policy/utils.py without importing wall_x.serving.__init__."""
+    utils_path = wall_x_root / "wall_x" / "serving" / "policy" / "utils.py"
+    spec = importlib.util.spec_from_file_location("wall_x_policy_utils_local", utils_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load prepare_batch from {utils_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.prepare_batch
+
+
+def extract_predict_action(output):
+    if isinstance(output, torch.Tensor):
+        return output
+
+    if isinstance(output, dict):
+        for key in ("predict_action", "actions", "action", "pred_action"):
+            if key in output:
+                return output[key]
+
+    if hasattr(output, "predict_action"):
+        return output.predict_action
+
+    if isinstance(output, (tuple, list)):
+        for item in output:
+            if isinstance(item, torch.Tensor) and item.ndim == 3:
+                return item
+
+    raise RuntimeError(f"cannot extract predict_action from output type={type(output)}")
+
+
+def make_predict_request(
+    *,
+    checkpoint: Path,
+    wall_x_root: Path,
+    device: torch.device,
+) -> WallOSSFlowPredictRequest:
+    if str(wall_x_root) not in sys.path:
+        sys.path.insert(0, str(wall_x_root))
+
+    from wall_x.model.action_head import Normalizer
+    from wall_x.utils.constant import action_statistic_dof
+
+    prepare_batch = _load_prepare_batch(wall_x_root)
+
+    cfg = WallOSSFlowConfig.from_checkpoint(checkpoint)
+    raw_cfg = json.loads((checkpoint / "config.json").read_text())
+
+    processor = AutoProcessor.from_pretrained(str(checkpoint), trust_remote_code=True)
+    normalizer_propri = Normalizer(action_statistic_dof, raw_cfg["agent_pos_config"])
+
+    camera_key = ["camera_0", "camera_1"]
+    obs = {
+        "camera_0": np.zeros((256, 256, 3), dtype=np.uint8),
+        "camera_1": np.full((256, 256, 3), 127, dtype=np.uint8),
+        "prompt": "Pick up the object and move it to the target position.",
+        "state": np.zeros((cfg.proprio_dim,), dtype=np.float32),
+        "dataset_names": cfg.dataset_name,
+    }
+
+    batch = prepare_batch(
+        obs=obs,
+        processor=processor,
+        normalizer_propri=normalizer_propri,
+        camera_key=camera_key,
+        agent_pos_dim=cfg.proprio_dim,
+        action_dim=cfg.action_dim,
+        pred_horizon=cfg.action_horizon,
+        fixed_action_dim=cfg.action_dim,
+        max_length=2048,
+        image_factor=28,
+        min_pixels=56 * 56,
+        max_pixels=256 * 28 * 28,
+        predict_mode="diffusion",
+        device=str(device),
+    )
+    batch = dict(batch)
+
+    return WallOSSFlowPredictRequest(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        moe_token_types=batch["moe_token_types"],
+        pixel_values=batch["pixel_values"],
+        image_grid_thw=batch["image_grid_thw"],
+        proprioception=batch["proprioception"],
+        agent_pos_mask=batch["agent_pos_mask"],
+        dof_mask=batch["dof_mask"],
+        dataset_names=batch["dataset_names"],
+        predict_mode="diffusion",
+        action_dim=cfg.action_dim,
+        action_horizon=cfg.action_horizon,
+    )
+
+
+def benchmark(
+    engine: Engine,
+    request: WallOSSFlowPredictRequest,
+    *,
+    n_warmup: int,
+    n_timed: int,
+):
+    output = None
+
+    for _ in range(n_warmup):
+        output = engine.step(request)
+
+    torch.cuda.synchronize()
+
+    times_ms: list[float] = []
+    for _ in range(n_timed):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        output = engine.step(request)
+        end.record()
+        torch.cuda.synchronize()
+        times_ms.append(start.elapsed_time(end))
+
+    if output is None:
+        raise RuntimeError("benchmark did not run any engine.step call.")
+
+    return output, {
+        "mean": statistics.fmean(times_ms),
+        "median": statistics.median(times_ms),
+        "stdev": statistics.stdev(times_ms) if len(times_ms) > 1 else 0.0,
+        "min": min(times_ms),
+        "max": max(times_ms),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--wall-x-root", type=Path, default=Path("/phyai_workspace/src/wall-x"))
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--n-warmup", type=int, default=0)
+    parser.add_argument("--n-timed", type=int, default=1)
+    args = parser.parse_args()
+
+    if str(args.wall_x_root) not in sys.path:
+        sys.path.insert(0, str(args.wall_x_root))
+
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+
+    device = torch.device(args.device)
+    dtype = torch.bfloat16
+    plugin_cfg = WallOSSFlowConfig.from_checkpoint(args.checkpoint)
+
+    request = make_predict_request(
+        checkpoint=args.checkpoint,
+        wall_x_root=args.wall_x_root,
+        device=device,
+    )
+
+    engine = Engine(
+        EngineArgs(
+            plugin="walloss",
+            plugin_args=WallOSSArgs(
+                checkpoint_dir=args.checkpoint,
+                max_batch_size=1,
+                action_horizon=plugin_cfg.action_horizon,
+                dataset_name=plugin_cfg.dataset_name,
+                precision_policy="selected_bf16",
+            ),
+            config=EngineConfig(
+                device=DeviceConfig(target=args.device, params_dtype=dtype),
+                runtime=RuntimeConfig(use_cuda_graph=False),
+            ),
+        )
+    )
+
+    try:
+        output, stats = benchmark(
+            engine,
+            request,
+            n_warmup=args.n_warmup,
+            n_timed=args.n_timed,
+        )
+        predict_action = extract_predict_action(output)
+
+        print(f"config                 : {plugin_cfg}")
+        print(f"predict_action shape   : {tuple(predict_action.shape)}")
+        print(f"predict_action dtype   : {predict_action.dtype}")
+        print(f"predict_action device  : {predict_action.device}")
+        print(f"has_nan                : {torch.isnan(predict_action).any().item()}")
+        print(f"has_inf                : {torch.isinf(predict_action).any().item()}")
+        print(f"predict_action min     : {float(predict_action.min().item())}")
+        print(f"predict_action max     : {float(predict_action.max().item())}")
+        print(f"predict_action mean    : {float(predict_action.float().mean().item())}")
+        print(
+            f"step latency           : mean={stats['mean']:.2f} ms  "
+            f"median={stats['median']:.2f} ms  std={stats['stdev']:.2f} ms  "
+            f"min={stats['min']:.2f} ms  max={stats['max']:.2f} ms  "
+            f"(n_warmup={args.n_warmup}, n_timed={args.n_timed})"
+        )
+
+        expected_shape = (1, plugin_cfg.action_horizon, plugin_cfg.action_dim)
+        if tuple(predict_action.shape) != expected_shape:
+            raise AssertionError(
+                f"predict_action shape {tuple(predict_action.shape)} != {expected_shape}"
+            )
+        if predict_action.dtype != torch.float32:
+            raise AssertionError(f"predict_action dtype is not float32: {predict_action.dtype}")
+        if predict_action.device.type != "cuda":
+            raise AssertionError(f"predict_action is not on CUDA: {predict_action.device}")
+        if not torch.isfinite(predict_action).all().item():
+            raise AssertionError("predict_action contains NaN or Inf")
+
+        print("WALLOSS ENGINE POLICY PREDICT DRY RUN PASSED")
+    finally:
+        engine.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/phyai/src/phyai/engine.py
+++ b/phyai/src/phyai/engine.py
@@ -387,3 +387,4 @@ __all__ = [
 # ---------------------------------------------------------------------- #
 
 from phyai.models.pi05 import main_pi05 as _main_pi05  # noqa: E402, F401
+from phyai.models.walloss import main_walloss as _main_walloss  # noqa: E402, F401

--- a/phyai/src/phyai/models/walloss/__init__.py
+++ b/phyai/src/phyai/models/walloss/__init__.py
@@ -1,0 +1,20 @@
+"""phyai.models.walloss — first-version WALL-OSS-FLOW plugin."""
+
+from __future__ import annotations
+
+from phyai.models.walloss.configuration_walloss import WallOSSFlowConfig
+from phyai.models.walloss.main_walloss import WallOSSArgs, WallOSSEntry
+from phyai.models.walloss.scheduler_ws1_walloss import (
+    WallOSSFlowPredictRequest,
+    WallOSSFlowRequest,
+    WallOSSFlowWS1Scheduler,
+)
+
+__all__ = [
+    "WallOSSArgs",
+    "WallOSSEntry",
+    "WallOSSFlowConfig",
+    "WallOSSFlowPredictRequest",
+    "WallOSSFlowRequest",
+    "WallOSSFlowWS1Scheduler",
+]

--- a/phyai/src/phyai/models/walloss/configuration_walloss.py
+++ b/phyai/src/phyai/models/walloss/configuration_walloss.py
@@ -1,0 +1,75 @@
+"""Minimal configuration helpers for WALL-OSS-FLOW.
+
+This file deliberately does not re-implement the wall-x model config.
+The first PhyAI plugin version treats wall-x as the source of truth and
+only extracts the dimensions needed for request validation.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _sum_dim(config: dict[str, int] | None, *, name: str) -> int:
+    if not isinstance(config, dict) or not config:
+        raise ValueError(f"{name} must be a non-empty dict, got {type(config).__name__}.")
+    try:
+        return sum(int(v) for v in config.values())
+    except Exception as exc:
+        raise ValueError(f"failed to sum {name}: {config!r}") from exc
+
+
+@dataclass(frozen=True)
+class WallOSSFlowConfig:
+    """Small runtime config for the first WALL-OSS-FLOW PhyAI plugin.
+
+    The true model architecture remains owned by wall-x's config.json and
+    Qwen2_5_VLMoEForAction.from_pretrained(). This dataclass only records
+    the fields the scheduler must validate.
+    """
+
+    checkpoint_dir: Path
+    model_type: str
+    vocab_size: int
+    action_dim: int
+    proprio_dim: int
+    action_horizon: int = 32
+    dataset_name: str = "x2_normal"
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        checkpoint_dir: str | Path,
+        *,
+        action_horizon: int = 32,
+        dataset_name: str = "x2_normal",
+    ) -> "WallOSSFlowConfig":
+        checkpoint_dir = Path(checkpoint_dir)
+        cfg_path = checkpoint_dir / "config.json"
+        if not cfg_path.is_file():
+            raise FileNotFoundError(f"missing wall-oss config.json: {cfg_path}")
+
+        cfg = json.loads(cfg_path.read_text())
+
+        model_type = str(cfg.get("model_type", ""))
+        if model_type != "qwen2_5_vl":
+            raise ValueError(
+                f"expected WALL-OSS-FLOW model_type='qwen2_5_vl', got {model_type!r}."
+            )
+        if "vocab_size" not in cfg:
+            raise ValueError(f"missing required key 'vocab_size' in {cfg_path}.")
+
+        action_dim = _sum_dim(cfg.get("dof_config"), name="dof_config")
+        proprio_dim = _sum_dim(cfg.get("agent_pos_config"), name="agent_pos_config")
+
+        return cls(
+            checkpoint_dir=checkpoint_dir,
+            model_type=model_type,
+            vocab_size=int(cfg["vocab_size"]),
+            action_dim=action_dim,
+            proprio_dim=proprio_dim,
+            action_horizon=int(action_horizon),
+            dataset_name=str(dataset_name),
+        )

--- a/phyai/src/phyai/models/walloss/main_walloss.py
+++ b/phyai/src/phyai/models/walloss/main_walloss.py
@@ -1,0 +1,97 @@
+"""WALL-OSS-FLOW plugin entry for PhyAI.
+
+First-version scope:
+- FLOW only, not FAST;
+- wall-oss-0.5 is a later migration target;
+- reuse wall-x Qwen2_5_VLMoEForAction instead of reimplementing model internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar
+
+import torch
+
+from phyai.engine import Engine, Entry, EntryArgs
+from phyai.engine_config import get_engine_config
+from phyai.models.walloss.configuration_walloss import WallOSSFlowConfig
+from phyai.models.walloss.model_runner_walloss import WallOSSFlowRunner
+from phyai.models.walloss.scheduler_ws1_walloss import (
+    WallOSSFlowPredictRequest,
+    WallOSSFlowRequest,
+    WallOSSFlowWS1Scheduler,
+)
+
+
+@dataclass
+class WallOSSArgs(EntryArgs):
+    """Args bundle for the first-version WALL-OSS-FLOW plugin.
+
+    Scope note:
+    - FLOW is the current target;
+    - FAST is intentionally out of scope for this first version;
+    - wall-oss-0.5 should be handled later by adapting this wrapper, not by
+      hard-coding old FLOW dimensions into future code.
+    """
+
+    checkpoint_dir: str | Path
+    max_batch_size: int = 1
+    action_horizon: int = 32
+    dataset_name: str = "x2_normal"
+    precision_policy: str = "full_bf16"
+
+
+@Engine.register
+class WallOSSEntry(Entry):
+    """PhyAI entry for WALL-OSS-FLOW."""
+
+    name: ClassVar[str] = "walloss"
+    args_cls: ClassVar[type[EntryArgs]] = WallOSSArgs
+
+    def __init__(self) -> None:
+        self.config: WallOSSFlowConfig | None = None
+        self.runner: WallOSSFlowRunner | None = None
+        self.scheduler: WallOSSFlowWS1Scheduler | None = None
+
+    def setup(self, args: WallOSSArgs) -> None:  # type: ignore[override]
+        eng = get_engine_config()
+        dtype = eng.device.params_dtype
+        if dtype is None:
+            dtype = torch.bfloat16
+
+        self.config = WallOSSFlowConfig.from_checkpoint(
+            args.checkpoint_dir,
+            action_horizon=args.action_horizon,
+            dataset_name=args.dataset_name,
+        )
+        self.runner = WallOSSFlowRunner(
+            self.config.checkpoint_dir,
+            device=eng.device.target,
+            dtype=dtype,
+            precision_policy=args.precision_policy,
+        )
+        self.scheduler = WallOSSFlowWS1Scheduler(
+            self.runner,
+            self.config,
+            max_batch_size=args.max_batch_size,
+            device=eng.device.target,
+            dtype=dtype,
+        )
+        self.scheduler.setup()
+
+    def step(self, request: WallOSSFlowRequest | WallOSSFlowPredictRequest):  # type: ignore[override]
+        if self.scheduler is None:
+            raise RuntimeError("WallOSSEntry.step called before setup().")
+        return self.scheduler.step(request)
+
+    def close(self) -> None:
+        if self.scheduler is not None:
+            self.scheduler.close()
+            self.scheduler = None
+        self.runner = None
+        self.config = None
+
+
+__all__ = ["WallOSSArgs", "WallOSSEntry"]

--- a/phyai/src/phyai/models/walloss/model_runner_walloss.py
+++ b/phyai/src/phyai/models/walloss/model_runner_walloss.py
@@ -1,0 +1,207 @@
+"""Model runner wrapper for WALL-OSS-FLOW.
+
+First version policy:
+- use the official wall-x model loader;
+- do not rewrite Qwen2.5-VL / MoE / action head;
+- keep the runner small so it can later be replaced by a deeper PhyAI-native runner.
+
+Two execution paths are intentionally separated:
+- ``forward`` keeps the original fake-validate logits path;
+- ``predict`` supports policy-level FLOW action prediction.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+
+from phyai.runtime.model_runner import ModelRunner
+
+
+PrecisionPolicy = Literal["full_bf16", "selected_bf16", "float32"]
+
+
+class WallOSSFlowRunner(ModelRunner):
+    """Thin wrapper around wall-x's Qwen2_5_VLMoEForAction."""
+
+    def __init__(
+        self,
+        checkpoint_dir: str | Path,
+        *,
+        device: torch.device | str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+        precision_policy: PrecisionPolicy = "full_bf16",
+    ) -> None:
+        self.checkpoint_dir = Path(checkpoint_dir)
+        self.device = torch.device(device)
+        self.dtype = dtype
+        self.precision_policy = precision_policy
+        self.model: torch.nn.Module | None = None
+
+        if self.precision_policy not in {"full_bf16", "selected_bf16", "float32"}:
+            raise ValueError(
+                "precision_policy must be one of "
+                f"{{'full_bf16', 'selected_bf16', 'float32'}}, got {precision_policy!r}."
+            )
+
+    def setup(self) -> None:
+        if self.model is not None:
+            return
+        if not self.checkpoint_dir.is_dir():
+            raise NotADirectoryError(f"checkpoint_dir is not a directory: {self.checkpoint_dir}")
+        if not (self.checkpoint_dir / "model.safetensors").is_file():
+            raise FileNotFoundError(
+                f"missing model.safetensors under checkpoint_dir: {self.checkpoint_dir}"
+            )
+
+        # Lazy import: importing phyai.engine should not require wall-x native
+        # extensions until the walloss plugin is actually set up.
+        from wall_x.model.qwen2_5_based.modeling_qwen2_5_vl_act import (
+            Qwen2_5_VLMoEForAction,
+        )
+
+        # Engine may set torch default dtype to the target params dtype while
+        # constructing plugins. Keep the wall-x loader on its official path:
+        # load weights under float32 default dtype first, then explicitly cast
+        # according to the requested precision policy.
+        old_default_dtype = torch.get_default_dtype()
+        try:
+            torch.set_default_dtype(torch.float32)
+            model = Qwen2_5_VLMoEForAction.from_pretrained(str(self.checkpoint_dir))
+        finally:
+            torch.set_default_dtype(old_default_dtype)
+
+        model = model.to(self.device)
+        model = self._apply_precision_policy(model)
+        model.eval()
+        self.model = model
+
+    def _apply_precision_policy(self, model: torch.nn.Module) -> torch.nn.Module:
+        if self.precision_policy == "selected_bf16":
+            if self.dtype != torch.bfloat16:
+                raise ValueError(
+                    "precision_policy='selected_bf16' requires dtype=torch.bfloat16, "
+                    f"got {self.dtype}."
+                )
+            if not hasattr(model, "to_bfloat16_for_selected_params"):
+                raise AttributeError(
+                    "wall-x model does not expose to_bfloat16_for_selected_params()."
+                )
+            return model.to_bfloat16_for_selected_params()
+
+        if self.precision_policy == "float32":
+            return model.float()
+
+        # Default first-version validate path: cast the whole model to runtime dtype.
+        if self.dtype == torch.bfloat16:
+            return model.bfloat16()
+        if self.dtype == torch.float16:
+            return model.half()
+        if self.dtype == torch.float32:
+            return model.float()
+        return model.to(dtype=self.dtype)
+
+    def _require_model(self) -> torch.nn.Module:
+        if self.model is None:
+            raise RuntimeError("WallOSSFlowRunner called before setup().")
+        return self.model
+
+    def _load_raw_config(self) -> dict[str, Any]:
+        cfg_path = self.checkpoint_dir / "config.json"
+        if not cfg_path.is_file():
+            raise FileNotFoundError(f"missing wall-oss config.json: {cfg_path}")
+        return json.loads(cfg_path.read_text())
+
+    def _has_normalizers(self) -> bool:
+        if self.model is None:
+            return False
+        action_preprocessor = getattr(self.model, "action_preprocessor", None)
+        if action_preprocessor is None:
+            return False
+        return (
+            getattr(action_preprocessor, "normalizer_action", None) is not None
+            and getattr(action_preprocessor, "normalizer_propri", None) is not None
+        )
+
+    def set_normalizers(
+        self,
+        normalizer_action: torch.nn.Module,
+        normalizer_propri: torch.nn.Module,
+    ) -> None:
+        """Set action/proprio normalizers on the model and move them to runner device."""
+        model = self._require_model()
+
+        normalizer_action = copy.deepcopy(normalizer_action).to(self.device)
+        normalizer_propri = copy.deepcopy(normalizer_propri).to(self.device)
+
+        if hasattr(model, "set_normalizer"):
+            model.set_normalizer(normalizer_action, normalizer_propri)
+        elif hasattr(model, "action_preprocessor"):
+            model.action_preprocessor.set_normalizer(normalizer_action, normalizer_propri)
+        else:
+            raise AttributeError("wall-x model has neither set_normalizer nor action_preprocessor.")
+
+    def setup_default_normalizers(self) -> None:
+        """Construct default wall-x normalizers from checkpoint config and constants.
+
+        FLOW checkpoint currently does not ship normalizer_action.pth /
+        normalizer_propri.pth in our environment. This mirrors the official dry-run
+        fallback based on wall_x.utils.constant.action_statistic_dof, then moves
+        the normalizers to the runner device.
+        """
+        if self._has_normalizers():
+            return
+
+        from wall_x.model.action_head import Normalizer
+        from wall_x.utils.constant import action_statistic_dof
+
+        raw_cfg = self._load_raw_config()
+
+        # Engine may keep torch default dtype as the runtime params dtype while
+        # constructing plugin components. wall-x normalizer statistics are
+        # official float32 constants, so construct them under float32 default
+        # dtype before moving them to the target device.
+        old_default_dtype = torch.get_default_dtype()
+        try:
+            torch.set_default_dtype(torch.float32)
+            normalizer_action = Normalizer(action_statistic_dof, raw_cfg["dof_config"])
+            normalizer_propri = Normalizer(action_statistic_dof, raw_cfg["agent_pos_config"])
+        finally:
+            torch.set_default_dtype(old_default_dtype)
+
+        self.set_normalizers(normalizer_action, normalizer_propri)
+
+    @torch.no_grad()
+    def forward(self, batch: dict[str, Any]) -> Any:
+        """Run the original validate/logits path."""
+        model = self._require_model()
+        return model(**batch, mode="validate")
+
+    @torch.no_grad()
+    def predict(
+        self,
+        batch: dict[str, Any],
+        *,
+        predict_mode: str = "diffusion",
+        action_dim: int,
+        action_horizon: int,
+    ) -> Any:
+        """Run policy-level FLOW action prediction."""
+        model = self._require_model()
+        self.setup_default_normalizers()
+        return model(
+            **batch,
+            mode="predict",
+            predict_mode=predict_mode,
+            action_dim=action_dim,
+            action_horizon=action_horizon,
+        )
+
+    def close(self) -> None:
+        self.model = None
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()

--- a/phyai/src/phyai/models/walloss/scheduler_ws1_walloss.py
+++ b/phyai/src/phyai/models/walloss/scheduler_ws1_walloss.py
@@ -1,0 +1,230 @@
+"""Single-card scheduler for the first WALL-OSS-FLOW PhyAI plugin."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+
+from phyai.models.walloss.configuration_walloss import WallOSSFlowConfig
+from phyai.models.walloss.model_runner_walloss import WallOSSFlowRunner
+from phyai.runtime.schedule import Scheduler
+
+
+@dataclass
+class WallOSSFlowRequest:
+    """One WALL-OSS-FLOW validate request.
+
+    This mirrors the already-validated wall-x fake inference path:
+    input_ids, attention_mask, moe_token_types, position_ids,
+    proprioception, agent_pos_mask, dof_mask, dataset_names.
+    """
+
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    moe_token_types: torch.Tensor
+    position_ids: torch.Tensor
+    proprioception: torch.Tensor
+    agent_pos_mask: torch.Tensor
+    dof_mask: torch.Tensor
+    dataset_names: Sequence[str] | str = "x2_normal"
+
+
+@dataclass
+class WallOSSFlowPredictRequest:
+    """One WALL-OSS-FLOW policy predict request.
+
+    This request is intentionally separate from ``WallOSSFlowRequest`` because
+    the real policy path consumes processor outputs such as pixel_values and
+    image_grid_thw, calls mode='predict', and returns predict_action instead of
+    validate logits.
+    """
+
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    moe_token_types: torch.Tensor
+    pixel_values: torch.Tensor
+    image_grid_thw: torch.Tensor
+    proprioception: torch.Tensor
+    agent_pos_mask: torch.Tensor
+    dof_mask: torch.Tensor
+    dataset_names: Sequence[str] | str = "x2_normal"
+    predict_mode: str = "diffusion"
+    action_dim: int | None = None
+    action_horizon: int | None = None
+
+
+class WallOSSFlowWS1Scheduler(Scheduler):
+    """Minimal single-GPU scheduler for WALL-OSS-FLOW.
+
+    It owns one runner and performs shape / dtype / device normalization before
+    calling the official wall-x model.
+    """
+
+    def __init__(
+        self,
+        runner: WallOSSFlowRunner,
+        config: WallOSSFlowConfig,
+        *,
+        max_batch_size: int = 1,
+        device: torch.device | str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        self.runner = runner
+        self.config = config
+        self.max_batch_size = int(max_batch_size)
+        self.device = torch.device(device)
+        self.dtype = dtype
+        if self.max_batch_size <= 0:
+            raise ValueError(f"max_batch_size must be positive, got {max_batch_size}.")
+
+    def setup(self) -> None:
+        self.runner.setup()
+
+    @torch.no_grad()
+    def step(self, request: WallOSSFlowRequest | WallOSSFlowPredictRequest):
+        if isinstance(request, WallOSSFlowPredictRequest):
+            self._validate_predict(request)
+            batch = self._to_wallx_predict_batch(request)
+            return self.runner.predict(
+                batch,
+                predict_mode=request.predict_mode,
+                action_dim=request.action_dim or self.config.action_dim,
+                action_horizon=request.action_horizon or self.config.action_horizon,
+            )
+
+        if isinstance(request, WallOSSFlowRequest):
+            self._validate(request)
+            batch = self._to_wallx_batch(request)
+            return self.runner.forward(batch)
+
+        raise TypeError(f"unsupported WALL-OSS request type: {type(request)!r}")
+
+    def _dataset_names(self, dataset_names: Sequence[str] | str, batch_size: int) -> list[str]:
+        if isinstance(dataset_names, str):
+            return [dataset_names] * batch_size
+        dataset_names = list(dataset_names)
+        if len(dataset_names) != batch_size:
+            raise ValueError(
+                f"dataset_names length {len(dataset_names)} != batch size {batch_size}."
+            )
+        return dataset_names
+
+    def _to_wallx_batch(self, req: WallOSSFlowRequest) -> dict:
+        dataset_names = self._dataset_names(req.dataset_names, int(req.input_ids.shape[0]))
+
+        return {
+            "input_ids": req.input_ids.to(device=self.device, dtype=torch.long),
+            "attention_mask": req.attention_mask.to(device=self.device, dtype=torch.long),
+            "moe_token_types": req.moe_token_types.to(device=self.device, dtype=torch.long),
+            "position_ids": req.position_ids.to(device=self.device, dtype=torch.long),
+            "proprioception": req.proprioception.to(device=self.device, dtype=self.dtype),
+            "agent_pos_mask": req.agent_pos_mask.to(device=self.device, dtype=self.dtype),
+            "dof_mask": req.dof_mask.to(device=self.device, dtype=self.dtype),
+            "dataset_names": dataset_names,
+        }
+
+    def _to_wallx_predict_batch(self, req: WallOSSFlowPredictRequest) -> dict:
+        dataset_names = self._dataset_names(req.dataset_names, int(req.input_ids.shape[0]))
+
+        # The policy path keeps action/proprio tensors in fp32 because wall-x's
+        # selected-bf16 policy keeps action_preprocessor parameters in fp32.
+        return {
+            "input_ids": req.input_ids.to(device=self.device, dtype=torch.long),
+            "attention_mask": req.attention_mask.to(device=self.device, dtype=torch.long),
+            "moe_token_types": req.moe_token_types.to(device=self.device, dtype=torch.bool),
+            "pixel_values": req.pixel_values.to(device=self.device),
+            "image_grid_thw": req.image_grid_thw.to(device=self.device, dtype=torch.long),
+            "proprioception": req.proprioception.to(device=self.device, dtype=torch.float32),
+            "agent_pos_mask": req.agent_pos_mask.to(device=self.device, dtype=torch.float32),
+            "dof_mask": req.dof_mask.to(device=self.device, dtype=torch.float32),
+            "dataset_names": dataset_names,
+        }
+
+    def _validate(self, req: WallOSSFlowRequest) -> None:
+        B, T = req.input_ids.shape
+        cfg = self.config
+
+        if not 1 <= B <= self.max_batch_size:
+            raise ValueError(f"batch size {B} not in [1, {self.max_batch_size}].")
+
+        expected_2d = (B, T)
+        for name in ("attention_mask", "moe_token_types", "position_ids"):
+            value = getattr(req, name)
+            if tuple(value.shape) != expected_2d:
+                raise ValueError(f"{name} shape {tuple(value.shape)} != {expected_2d}.")
+
+        if tuple(req.proprioception.shape) != (B, 1, cfg.proprio_dim):
+            raise ValueError(
+                f"proprioception shape {tuple(req.proprioception.shape)} != "
+                f"({B}, 1, {cfg.proprio_dim})."
+            )
+
+        if tuple(req.agent_pos_mask.shape) != (B, 1, cfg.proprio_dim):
+            raise ValueError(
+                f"agent_pos_mask shape {tuple(req.agent_pos_mask.shape)} != "
+                f"({B}, 1, {cfg.proprio_dim})."
+            )
+
+        if tuple(req.dof_mask.shape) != (B, cfg.action_horizon, cfg.action_dim):
+            raise ValueError(
+                f"dof_mask shape {tuple(req.dof_mask.shape)} != "
+                f"({B}, {cfg.action_horizon}, {cfg.action_dim})."
+            )
+
+        self._dataset_names(req.dataset_names, B)
+
+    def _validate_predict(self, req: WallOSSFlowPredictRequest) -> None:
+        B, T = req.input_ids.shape
+        cfg = self.config
+
+        if not 1 <= B <= self.max_batch_size:
+            raise ValueError(f"batch size {B} not in [1, {self.max_batch_size}].")
+
+        expected_2d = (B, T)
+        for name in ("attention_mask", "moe_token_types"):
+            value = getattr(req, name)
+            if tuple(value.shape) != expected_2d:
+                raise ValueError(f"{name} shape {tuple(value.shape)} != {expected_2d}.")
+
+        if req.pixel_values.ndim != 2:
+            raise ValueError(f"pixel_values must be 2-D, got shape {tuple(req.pixel_values.shape)}.")
+
+        if req.image_grid_thw.ndim != 2 or req.image_grid_thw.shape[-1] != 3:
+            raise ValueError(
+                "image_grid_thw must have shape (num_images, 3), "
+                f"got {tuple(req.image_grid_thw.shape)}."
+            )
+
+        if tuple(req.proprioception.shape) != (B, 1, cfg.proprio_dim):
+            raise ValueError(
+                f"proprioception shape {tuple(req.proprioception.shape)} != "
+                f"({B}, 1, {cfg.proprio_dim})."
+            )
+
+        if tuple(req.agent_pos_mask.shape) != (B, 1, cfg.proprio_dim):
+            raise ValueError(
+                f"agent_pos_mask shape {tuple(req.agent_pos_mask.shape)} != "
+                f"({B}, 1, {cfg.proprio_dim})."
+            )
+
+        action_dim = req.action_dim or cfg.action_dim
+        action_horizon = req.action_horizon or cfg.action_horizon
+        if tuple(req.dof_mask.shape) != (B, action_horizon, action_dim):
+            raise ValueError(
+                f"dof_mask shape {tuple(req.dof_mask.shape)} != "
+                f"({B}, {action_horizon}, {action_dim})."
+            )
+
+        self._dataset_names(req.dataset_names, B)
+
+    def close(self) -> None:
+        self.runner.close()
+
+
+__all__ = [
+    "WallOSSFlowPredictRequest",
+    "WallOSSFlowRequest",
+    "WallOSSFlowWS1Scheduler",
+]


### PR DESCRIPTION
## Summary

This PR adds the first PhyAI Engine plugin integration for WALL-OSS-FLOW.

The implementation follows the existing PhyAI Engine/plugin pattern and registers a new `walloss` plugin. It includes a dedicated configuration wrapper, model runner, single-card scheduler, request object, and reproducible dry-run examples.

The first version keeps the official WALL-OSS-FLOW model path isolated inside the new plugin and does not modify the PI0.5 plugin or other existing model plugins.

## Changes

* Added `phyai.models.walloss`

  * `WallOSSArgs`
  * `WallOSSEntry`
  * `WallOSSConfig`
  * `WallOSSRunner`
  * `WallOSSWS1Scheduler`
  * request / response objects for validation and policy prediction
* Added examples:

  * `examples/run_walloss_flow.py`
  * `examples/run_walloss_flow_predict_dryrun.py`
* Registered the `walloss` plugin in `phyai.engine`

## Verification

The plugin was verified locally with the WALL-OSS-FLOW checkpoint.

Validation / smoke test:

* Logits shape: `(1, 50, 153715)`
* Dtype: `torch.bfloat16`
* Device: `cuda:0`
* NaN / Inf check: passed

Policy prediction dry run:

* Action shape: `(1, 32, 20)`
* Dtype: `torch.float32`
* Device: `cuda:0`
* NaN / Inf check: passed

Official WALL-X vs PhyAI Engine fixed-seed comparison:

* `max_abs_diff`: `0.0`
* `torch.equal`: `True`

## Benchmark

Local benchmark results:

* Fake validation mean latency: approximately `57.22 ms`
* Policy prediction mean latency: approximately `711.79 ms`

## Scope

This PR only adds the WALL-OSS-FLOW Engine plugin. WALL-OSS-0.5 is kept in a separate follow-up branch / PR so that the two integrations can be reviewed independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Integrated WALL-OSS-FLOW model as a PhyAI engine plugin, supporting both inference and policy prediction modes
- Added example scripts for benchmarking model inference latency and validating policy prediction outputs with configurable warmup and timing iterations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->