### PR TITLE
fix(phyai): Fix/fp8 per tensor scale layout

### DIFF
--- a/phyai/src/phyai/layers/linear/backends/torch.py
+++ b/phyai/src/phyai/layers/linear/backends/torch.py
@@ -99,7 +99,7 @@ class TorchKernel:
         # Static per-tensor input scale with shape (M, 1).
         a_scale = layer.input_scale
         if a_scale.ndim == 1 and a_scale.numel() == 1:
-            a_scale = a_scale.reshape(-1, 1)
+            a_scale = a_scale.view(1, 1).expand(x_2d.shape[0], 1).contiguous()
         out = torch._scaled_mm(
             x_2d,
             layer.weight.t(),

--- a/phyai/src/phyai/layers/linear/backends/torch.py
+++ b/phyai/src/phyai/layers/linear/backends/torch.py
@@ -95,11 +95,11 @@ class TorchKernel:
         # per-channel shape (N,); broadcast it as (1, N).
         w_scale = layer.weight_scale
         if w_scale.ndim == 1:
-            w_scale = w_scale.reshape(1, -1)
-        # Static per-tensor input scale is scalar (1,).
+            w_scale = w_scale.reshape(1, -1).contiguous()
+        # Static per-tensor input scale with shape (M, 1).
         a_scale = layer.input_scale
         if a_scale.ndim == 1 and a_scale.numel() == 1:
-            a_scale = a_scale.reshape(1, 1)
+            a_scale = a_scale.reshape(-1, 1)
         out = torch._scaled_mm(
             x_2d,
             layer.weight.t(),

--- a/phyai/src/phyai/layers/quant/fp8.py
+++ b/phyai/src/phyai/layers/quant/fp8.py
@@ -145,7 +145,6 @@ class Fp8Spec:
                 .clamp(-_FP8_E4M3_AMAX, _FP8_E4M3_AMAX)
                 .to(torch.float8_e4m3fn)
             )
-            layer.input_scale = nn.Parameter(layer.input_scale.view(1, 1).expand(x.shape[0], 1).contiguous(), requires_grad=False)
             return ActivationView(x_q, layer.input_scale, Granularity.PER_TENSOR)
 
         if self.granularity in (Granularity.PER_CHANNEL, Granularity.BLOCK):

--- a/phyai/src/phyai/layers/quant/fp8.py
+++ b/phyai/src/phyai/layers/quant/fp8.py
@@ -145,6 +145,7 @@ class Fp8Spec:
                 .clamp(-_FP8_E4M3_AMAX, _FP8_E4M3_AMAX)
                 .to(torch.float8_e4m3fn)
             )
+            layer.input_scale = nn.Parameter(layer.input_scale.view(1, 1).expand(x.shape[0], 1).contiguous(), requires_grad=False)
             return ActivationView(x_q, layer.input_scale, Granularity.PER_TENSOR)
 
         if self.granularity in (Granularity.PER_CHANNEL, Granularity.BLOCK):


### PR DESCRIPTION
fix #31 

change the shape of weight scale and input scale to adapt to `torch._scaled_mm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 per-tensor scaling so both weights and activations are reshaped consistently before quantized matrix multiplication.
  * Fixed inconsistent handling of scalar versus batch-shaped activation scales to improve correct broadcasting during FP8 activation quantization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->