### PR TITLE
feat(phyai): support nvfp4 linear

### DIFF
--- a/phyai/src/phyai/layers/linear/__init__.py
+++ b/phyai/src/phyai/layers/linear/__init__.py
@@ -46,7 +46,7 @@ from phyai.layers.linear.registry import (
     list_registered_linear_kernels,
     register_linear_kernel,
 )
-from phyai.layers.linear.spec import ActivationView, Bf16Spec, Fp8Spec
+from phyai.layers.linear.spec import ActivationView, Bf16Spec, Fp8Spec, Nvfp4Spec
 from phyai.layers.quant import AllocationRequest, WeightSpec
 from phyai.utils.cuda import sm_arch
 
@@ -74,6 +74,8 @@ def supported_specs_for_sm(sm: int) -> list[str]:
     if sm >= 100:
         # flashinfer gemm_fp8_nt_groupwise (DeepSeek-V3 block-fp8).
         specs.append("fp8_block_128_128")
+        # flashinfer mm_fp4 (Blackwell NVFP4) with 128x4 scale layout.
+        specs.append("nvfp4_block_16_128x4")
     return specs
 
 
@@ -136,6 +138,7 @@ __all__ = [
     # specs
     "Bf16Spec",
     "Fp8Spec",
+    "Nvfp4Spec",
     "ActivationView",
     "AllocationRequest",
     "WeightSpec",

--- a/phyai/src/phyai/layers/linear/backends/flashinfer.py
+++ b/phyai/src/phyai/layers/linear/backends/flashinfer.py
@@ -1,4 +1,4 @@
-"""FlashInferKernel — bf16 (cublasLt/cuDNN/TGV) + block-fp8 groupwise GEMM.
+"""FlashInferKernel — bf16 (cublasLt/cuDNN/TGV) + block-fp8 groupwise GEMM + NVFP4 GEMM.
 
 flashinfer's ``mm_fp8`` ≠ generic fp8 GEMM: it targets ``trtllm_low_latency``
 with pre-processed weights and a single alpha scalar. Per-tensor and
@@ -6,7 +6,8 @@ per-channel fp8 therefore stay on :class:`TorchKernel` for now; this kernel
 covers the paths where flashinfer is unambiguously the best choice:
 
 * bf16 GEMM on sm≥89 (cuBLASLt / cuDNN / TGV, autoselected by flashinfer);
-* block-FP8 (DeepSeek-V3 style) on sm≥100 via ``gemm_fp8_nt_groupwise``.
+* block-FP8 (DeepSeek-V3 style) on sm≥100 via ``gemm_fp8_nt_groupwise``;
+* NVFP4 on sm≥100 via ``mm_fp4`` with 128x4 scale-factor layout.
 
 If flashinfer is not installed, :meth:`can_handle` returns ``False`` for
 every probe and the fallback :class:`TorchKernel` picks up the work.
@@ -23,10 +24,14 @@ from phyai.layers.linear.registry import register_linear_kernel
 try:
     import flashinfer  # noqa: F401
     import flashinfer.gemm as _fi_gemm
+    from flashinfer.quantization import SfLayout as _FiSfLayout
+    from flashinfer.quantization import nvfp4_quantize as _fi_nvfp4_quantize
 
     _HAS_FLASHINFER = True
 except Exception:  # pragma: no cover — depends on install
     _fi_gemm = None  # type: ignore[assignment]
+    _FiSfLayout = None  # type: ignore[assignment]
+    _fi_nvfp4_quantize = None  # type: ignore[assignment]
     _HAS_FLASHINFER = False
 
 
@@ -35,15 +40,21 @@ except Exception:  # pragma: no cover — depends on install
         ("bf16", "prefill"),
         ("fp8_block_128_128", "prefill"),
         ("fp8_block_128_128", "decode"),
+        ("nvfp4_block_16_128x4", "prefill"),
+        ("nvfp4_block_16_128x4", "decode"),
     },
 )
 class FlashInferKernel:
-    """bf16 + block-fp8 via flashinfer.gemm.
+    """bf16 + block-fp8 + NVFP4 via flashinfer.gemm.
 
     For block-fp8 we assume DeepSeek-V3 style weight layout:
     ``layer.weight`` is ``(N, K)`` fp8_e4m3fn, ``layer.weight_scale`` is
     ``(N // bn, K // bk)`` fp32, and ``x`` gets rowwise-quantised to fp8
     with a ``(M, K // bk)`` scale tensor by :meth:`spec.quantize_activation`.
+
+    For NVFP4, ``layer.weight`` is packed ``(N, K // 2)`` uint8,
+    ``layer.weight_scale`` uses FlashInfer's 128x4 layout, and
+    ``layer.weight_global_scale`` is the per-tensor descale factor.
 
     ``prefer_for`` is attached at decoration time and consulted by
     :class:`phyai.layers.linear.registry.LinearKernelRegistry` —
@@ -73,6 +84,8 @@ class FlashInferKernel:
         if probe.spec_id.startswith("fp8_block_"):
             # gemm_fp8_nt_groupwise is sm100+ only today.
             return probe.sm >= 100
+        if probe.spec_id == "nvfp4_block_16_128x4":
+            return probe.sm >= 100 and probe.K % 16 == 0
         return False
 
     def apply(
@@ -86,6 +99,8 @@ class FlashInferKernel:
             return self._bf16(layer, x, bias)
         if spec.spec_id.startswith("fp8_block_"):
             return self._block_fp8(layer, x, bias)
+        if spec.spec_id == "nvfp4_block_16_128x4":
+            return self._nvfp4(layer, x, bias)
         raise RuntimeError(f"FlashInferKernel got unhandled spec_id={spec.spec_id!r}")
 
     # ------------------------------------------------------------------
@@ -136,6 +151,49 @@ class FlashInferKernel:
             b_scale=layer.weight_scale,
             scale_granularity_mnk=(1, bn, bk),
             out_dtype=x.dtype,
+        )
+        if bias is not None:
+            y = y + bias
+        return y.reshape(*x.shape[:-1], -1)
+
+    # ------------------------------------------------------------------
+    # nvfp4: mm_fp4 with 128x4 scale-factor layout
+    # ------------------------------------------------------------------
+
+    def _nvfp4(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        assert _fi_gemm is not None
+        assert _fi_nvfp4_quantize is not None
+        assert _FiSfLayout is not None
+        K = x.shape[-1]
+        x_2d = x.reshape(-1, K)
+        x_global_scale = (448.0 * 6.0) / x_2d.float().abs().nan_to_num().max().clamp_min(
+            1e-12
+        )
+        x_global_scale = x_global_scale.reshape(1).to(torch.float32)
+        act_x, act_scale = _fi_nvfp4_quantize(
+            x_2d,
+            x_global_scale,
+            sfLayout=_FiSfLayout.layout_128x4,
+            do_shuffle=False,
+            enable_pdl=False,
+        )
+        alpha = (layer.weight_global_scale / x_global_scale).to(torch.float32)
+        y = _fi_gemm.mm_fp4(
+            act_x,
+            layer.weight.t(),
+            act_scale,
+            layer.weight_scale.t().view(torch.uint8),
+            alpha,
+            x.dtype,
+            None,
+            block_size=16,
+            use_nvfp4=True,
+            backend="cudnn",
         )
         if bias is not None:
             y = y + bias

--- a/phyai/src/phyai/layers/linear/backends/torch.py
+++ b/phyai/src/phyai/layers/linear/backends/torch.py
@@ -17,6 +17,10 @@ from phyai.layers.linear.registry import register_linear_kernel
 
 
 _FP8_E4M3_AMAX = 448.0
+_E2M1_VALUES = torch.tensor(
+    [0, 0.5, 1, 1.5, 2, 3, 4, 6, -0, -0.5, -1, -1.5, -2, -3, -4, -6],
+    dtype=torch.float32,
+)
 
 
 def _expand_block_scale(
@@ -29,6 +33,40 @@ def _expand_block_scale(
     N, K = weight_shape
     expanded = scale.repeat_interleave(bn, dim=0).repeat_interleave(bk, dim=1)
     return expanded[:N, :K]
+
+
+def _unpack_e2m1(weight: torch.Tensor) -> torch.Tensor:
+    """Unpack ``(N, K//2)`` E2M1 bytes into a float32 ``(N, K)`` tensor."""
+    packed = weight.view(torch.uint8)
+    codes = torch.empty(
+        packed.shape[0],
+        packed.shape[1] * 2,
+        dtype=torch.uint8,
+        device=packed.device,
+    )
+    codes[:, 0::2] = packed & 0x0F
+    codes[:, 1::2] = (packed >> 4) & 0x0F
+    lut = _E2M1_VALUES.to(packed.device)
+    return lut[codes.long()]
+
+
+def _linear_nvfp4_scale(
+    scale: torch.Tensor,
+    weight_shape: tuple[int, ...],
+) -> torch.Tensor:
+    """Return the logical ``(N, K//16)`` scale view from a padded scale tensor."""
+    N, K_half = weight_shape
+    k_blocks = (K_half * 2) // 16
+    return scale[:N, :k_blocks]
+
+
+def _dequant_nvfp4_weight(layer: torch.nn.Module) -> torch.Tensor:
+    """Dequantise packed NVFP4 weight to float32 for the reference path."""
+    fp4 = _unpack_e2m1(layer.weight)
+    scale = _linear_nvfp4_scale(layer.weight_scale, tuple(layer.weight.shape)).float()
+    scale = scale.repeat_interleave(16, dim=1)
+    global_scale = layer.weight_global_scale.float().reshape(())
+    return fp4 * scale * global_scale
 
 
 @register_linear_kernel()
@@ -53,6 +91,8 @@ class TorchKernel:
             if probe.K % 16 != 0 or probe.N % 16 != 0:
                 return False
             return True
+        if probe.spec_id == "nvfp4_block_16_linear":
+            return True
         return False
 
     def apply(
@@ -71,6 +111,8 @@ class TorchKernel:
             return self._fp8_per_channel(layer, x, bias)
         if spec.spec_id.startswith("fp8_block_"):
             return self._fp8_block(layer, x, bias)
+        if spec.spec_id == "nvfp4_block_16_linear":
+            return self._nvfp4_reference(layer, x, bias)
 
         raise RuntimeError(f"TorchKernel got unhandled spec_id={spec.spec_id!r}")
 
@@ -148,4 +190,14 @@ class TorchKernel:
             tuple(layer.weight.shape),
             spec.block_shape,
         ).to(x.dtype)
+        return F.linear(x, w, bias)
+
+    def _nvfp4_reference(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Reference dequant + F.linear path. Correct but not fast."""
+        w = _dequant_nvfp4_weight(layer).to(x.dtype)
         return F.linear(x, w, bias)

--- a/phyai/src/phyai/layers/linear/layers.py
+++ b/phyai/src/phyai/layers/linear/layers.py
@@ -79,18 +79,33 @@ class LinearBase(nn.Module):
     def _attach_optional_scales(layer: nn.Module, hf_base: str) -> None:
         """Attach hf_keys/weight_loader/optional=True to spec-allocated scales.
 
-        ``Fp8Spec`` (and any future quant spec) creates ``weight_scale`` /
-        ``input_scale`` as parameters on the layer. They are absent in
-        non-quant checkpoints, so they're marked optional — missing keys
-        don't raise under ``strict=True`` and the spec's
+        ``Fp8Spec`` / ``Nvfp4Spec`` (and any future quant spec) create
+        scale parameters on the layer. They are absent in non-quant
+        checkpoints, so they're marked optional — missing keys don't
+        raise under ``strict=True`` and the spec's
         :meth:`process_after_loading` handles any shape fixup.
         """
-        for name in ("weight_scale", "input_scale"):
+        for name in ("weight_scale", "input_scale", "weight_global_scale"):
             p = getattr(layer, name, None)
             if isinstance(p, nn.Parameter):
                 p.hf_keys = [(f"{hf_base}.{name}", None)]
                 p.weight_loader = replicated()
                 p.optional = True
+
+    @staticmethod
+    def _attach_weight_loader(layer: nn.Module, loader) -> None:
+        load_weight = getattr(layer.spec, "load_weight", None)
+        if callable(load_weight):
+            layer.weight.weight_loader = (
+                lambda _param, loaded, shard_id: load_weight(
+                    layer,
+                    loaded,
+                    shard_id,
+                    loader,
+                )
+            )
+        else:
+            layer.weight.weight_loader = loader
 
 
 class ReplicatedLinear(LinearBase):
@@ -141,8 +156,9 @@ class ReplicatedLinear(LinearBase):
             self.register_parameter("bias", None)
 
         if prefix:
+            weight_loader = replicated()
             self.weight.hf_keys = [(f"{prefix}.weight", None)]
-            self.weight.weight_loader = replicated()
+            self._attach_weight_loader(self, weight_loader)
             if self.bias is not None:
                 self.bias.hf_keys = [(f"{prefix}.bias", None)]
                 self.bias.weight_loader = replicated()
@@ -251,8 +267,9 @@ class ColumnParallelLinear(LinearBase):
         # Non-fused column-parallel: subclasses (Merged / QKV) override
         # by re-attaching after super().__init__ returns.
         if prefix and len(per_rank_sizes) == 1:
+            weight_loader = sharded(dim=0, axis=axis, mesh=mesh_obj)
             self.weight.hf_keys = [(f"{prefix}.weight", None)]
-            self.weight.weight_loader = sharded(dim=0, axis=axis, mesh=mesh_obj)
+            self._attach_weight_loader(self, weight_loader)
             if self.bias is not None:
                 self.bias.hf_keys = [(f"{prefix}.bias", None)]
                 self.bias.weight_loader = sharded(dim=0, axis=axis, mesh=mesh_obj)
@@ -344,9 +361,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     bias_keys.append((f"{hf_base}.bias", i))
                 offset += per_rank
             self.weight.hf_keys = keys
-            self.weight.weight_loader = fused(
-                fuse_dim=0, legs=leg_dict, mesh=self._mesh
-            )
+            weight_loader = fused(fuse_dim=0, legs=leg_dict, mesh=self._mesh)
+            self._attach_weight_loader(self, weight_loader)
             if self.bias is not None:
                 self.bias.hf_keys = bias_keys
                 self.bias.weight_loader = fused(
@@ -465,9 +481,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                 if self.bias is not None:
                     bias_keys.append((f"{hf_base}.bias", kind))
             self.weight.hf_keys = keys
-            self.weight.weight_loader = fused(
-                fuse_dim=0, legs=leg_dict, mesh=self._mesh
-            )
+            weight_loader = fused(fuse_dim=0, legs=leg_dict, mesh=self._mesh)
+            self._attach_weight_loader(self, weight_loader)
             if self.bias is not None:
                 self.bias.hf_keys = bias_keys
                 self.bias.weight_loader = fused(
@@ -550,8 +565,9 @@ class RowParallelLinear(LinearBase):
             self.register_parameter("bias", None)
 
         if prefix:
+            weight_loader = sharded(dim=1, axis=axis, mesh=mesh_obj)
             self.weight.hf_keys = [(f"{prefix}.weight", None)]
-            self.weight.weight_loader = sharded(dim=1, axis=axis, mesh=mesh_obj)
+            self._attach_weight_loader(self, weight_loader)
             if self.bias is not None:
                 # Bias is replicated for row-parallel — full copy, no slice.
                 self.bias.hf_keys = [(f"{prefix}.bias", None)]

--- a/phyai/src/phyai/layers/linear/spec.py
+++ b/phyai/src/phyai/layers/linear/spec.py
@@ -1,7 +1,7 @@
 """Back-compat shim — the spec abstraction has moved to :mod:`phyai.layers.quant`.
 
 Existing imports such as
-``from phyai.layers.linear.spec import Bf16Spec, Fp8Spec, ActivationView``
+``from phyai.layers.linear.spec import Bf16Spec, Fp8Spec, Nvfp4Spec, ActivationView``
 keep working; new code should import from :mod:`phyai.layers.quant`.
 """
 
@@ -13,6 +13,7 @@ from phyai.layers.quant import (
     Bf16Spec,
     Fp8Spec,
     LinearActivationQuant,
+    Nvfp4Spec,
     WeightSpec,
 )
 from phyai.layers.quant.fp8 import _convert_to_channelwise
@@ -22,6 +23,7 @@ __all__ = [
     "AllocationRequest",
     "Bf16Spec",
     "Fp8Spec",
+    "Nvfp4Spec",
     "LinearActivationQuant",
     "WeightSpec",
     "_convert_to_channelwise",

--- a/phyai/src/phyai/layers/quant/__init__.py
+++ b/phyai/src/phyai/layers/quant/__init__.py
@@ -10,7 +10,7 @@ Public surface::
     from phyai.layers.quant import (
         AllocationRequest, WeightSpec,                   # base
         Granularity,                                     # scale layout enum
-        Bf16Spec, Fp8Spec,                               # concrete specs
+        Bf16Spec, Fp8Spec, Nvfp4Spec,                    # concrete specs
         ActivationView, LinearActivationQuant,           # linear-only mixin
     )
 """
@@ -22,6 +22,7 @@ from phyai.layers.quant.bf16 import Bf16Spec
 from phyai.layers.quant.fp8 import Fp8Spec
 from phyai.layers.quant.granularity import Granularity
 from phyai.layers.quant.linear import ActivationView, LinearActivationQuant
+from phyai.layers.quant.nvfp4 import Nvfp4Spec
 
 __all__ = [
     "AllocationRequest",
@@ -29,6 +30,7 @@ __all__ = [
     "Granularity",
     "Bf16Spec",
     "Fp8Spec",
+    "Nvfp4Spec",
     "ActivationView",
     "LinearActivationQuant",
 ]

--- a/phyai/src/phyai/layers/quant/nvfp4.py
+++ b/phyai/src/phyai/layers/quant/nvfp4.py
@@ -1,0 +1,225 @@
+"""Nvfp4Spec — packed E2M1 FP4 weight with FP8 block scales.
+
+NVFP4 stores two E2M1 values per byte and uses one FP8-E4M3 scale for
+every 16 values along the K dimension. The logical weight is still the
+linear ``(N, K)`` matrix, but the stored parameter is ``(N, K // 2)``.
+
+Two scale layouts are useful:
+
+* ``"linear"`` — test/reference layout, ``(N, K // 16)``.
+* ``"128x4"`` — FlashInfer / Blackwell GEMM layout, padded to
+  ``(ceil(N, 128), ceil(K // 16, 4))``.
+
+The activation path is handled by the backend because FlashInfer's FP4
+GEMM needs both the per-block activation scales and a separate global
+scale scalar, which does not fit the current :class:`ActivationView`
+shape used by FP8.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+import torch
+import torch.nn as nn
+
+from phyai.layers.quant.base import AllocationRequest
+
+
+_NVFP4_BLOCK_SIZE = 16
+_FP8_E4M3_AMAX = 448.0
+_NVFP4_MAX = 6.0
+_E2M1_THRESHOLDS = (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+
+
+def _round_up(x: int, multiple: int) -> int:
+    return ((x + multiple - 1) // multiple) * multiple
+
+
+def _scale_shape(
+    out_per_rank: int,
+    in_per_rank: int,
+    scale_layout: Literal["linear", "128x4"],
+) -> tuple[int, int]:
+    k_blocks = in_per_rank // _NVFP4_BLOCK_SIZE
+    if scale_layout == "linear":
+        return out_per_rank, k_blocks
+    if scale_layout == "128x4":
+        return _round_up(out_per_rank, 128), _round_up(k_blocks, 4)
+    raise ValueError(
+        f"Nvfp4Spec scale_layout must be 'linear' or '128x4', got {scale_layout!r}"
+    )
+
+
+def _per_tensor_amax_to_scale(amax: torch.Tensor) -> torch.Tensor:
+    """Convert tensor amax to the TorchAO-style NVFP4 per-tensor scale."""
+    return amax.float() / (_FP8_E4M3_AMAX * _NVFP4_MAX)
+
+
+def _quantize_e2m1(data: torch.Tensor) -> torch.Tensor:
+    thresholds = torch.tensor(_E2M1_THRESHOLDS, dtype=torch.float32, device=data.device)
+    mag = torch.bucketize(data.abs(), thresholds).to(torch.uint8)
+    sign = (data < 0).to(torch.uint8) << 3
+    codes = (mag | sign).contiguous()
+    return codes[:, 0::2] | (codes[:, 1::2] << 4)
+
+
+def _quantize_nvfp4_linear(
+    weight: torch.Tensor,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    per_tensor_scale = _per_tensor_amax_to_scale(weight.abs().amax()).clamp_min(1e-12)
+    src = weight.float().reshape(weight.shape[0], -1, block_size)
+    block_scale = src.abs().amax(dim=-1) / _NVFP4_MAX
+    block_scale = (block_scale / per_tensor_scale).clamp(
+        torch.finfo(torch.float8_e4m3fn).tiny,
+        _FP8_E4M3_AMAX,
+    )
+    block_scale_fp8 = block_scale.to(torch.float8_e4m3fn)
+    reciprocal = (1.0 / per_tensor_scale) / block_scale_fp8.float()
+    scaled = (src * reciprocal.unsqueeze(-1)).clamp(-_NVFP4_MAX, _NVFP4_MAX)
+    packed = _quantize_e2m1(scaled.reshape(weight.shape))
+    return packed, block_scale_fp8, per_tensor_scale.reshape(1)
+
+
+@dataclass
+class Nvfp4Spec:
+    """NVFP4 Linear weight spec.
+
+    ``scale_layout="128x4"`` is the production layout consumed by
+    FlashInfer's ``mm_fp4`` backend. ``"linear"`` is kept for the Torch
+    reference path and small CPU tests.
+    """
+
+    scale_layout: Literal["linear", "128x4"] = "128x4"
+    weight_dtype: torch.dtype = torch.uint8
+    block_size: int = _NVFP4_BLOCK_SIZE
+
+    def __post_init__(self) -> None:
+        if self.block_size != _NVFP4_BLOCK_SIZE:
+            raise ValueError("Nvfp4Spec only supports block_size=16")
+        if self.scale_layout not in ("linear", "128x4"):
+            raise ValueError(
+                f"Nvfp4Spec scale_layout must be 'linear' or '128x4', "
+                f"got {self.scale_layout!r}"
+            )
+
+    @property
+    def spec_id(self) -> str:
+        return f"nvfp4_block_{self.block_size}_{self.scale_layout}"
+
+    def allocate(self, layer: nn.Module, request: AllocationRequest) -> None:
+        if len(request.weight_shape) != 2:
+            raise ValueError(
+                f"Nvfp4Spec.allocate expects a 2-D weight_shape (N, K), "
+                f"got {request.weight_shape!r}"
+            )
+        out_per_rank, in_per_rank = request.weight_shape
+        if in_per_rank % self.block_size != 0:
+            raise ValueError(
+                f"Nvfp4Spec: in_per_rank={in_per_rank} not divisible by "
+                f"block_size={self.block_size}"
+            )
+        device = request.device
+
+        layer.weight = nn.Parameter(
+            torch.empty(
+                out_per_rank,
+                in_per_rank // 2,
+                dtype=self.weight_dtype,
+                device=device,
+            ),
+            requires_grad=False,
+        )
+        layer.weight_scale = nn.Parameter(
+            torch.ones(
+                _scale_shape(out_per_rank, in_per_rank, self.scale_layout),
+                dtype=torch.float8_e4m3fn,
+                device=device,
+            ),
+            requires_grad=False,
+        )
+        layer.weight_global_scale = nn.Parameter(
+            torch.ones(1, dtype=torch.float32, device=device),
+            requires_grad=False,
+        )
+        layer._nvfp4_pending_weight = None
+        layer.logical_widths = list(request.logical_widths)
+
+    def process_after_loading(self, layer: nn.Module) -> None:
+        pending = getattr(layer, "_nvfp4_pending_weight", None)
+        if pending is not None:
+            print("Nvfp4Spec: quantizing loaded weight to packed NVFP4")
+            self.quantize_loaded_weight(layer, pending)
+            layer._nvfp4_pending_weight = None
+        return None
+
+    def load_weight(
+        self,
+        layer: nn.Module,
+        loaded: torch.Tensor,
+        shard_id: "int | str | None",
+        default_loader: Callable[[nn.Parameter, torch.Tensor, object], None],
+    ) -> None:
+        logical_shape = (layer.weight.shape[0], layer.weight.shape[1] * 2)
+        if loaded.dtype in (torch.float16, torch.bfloat16, torch.float32):
+            pending = getattr(layer, "_nvfp4_pending_weight", None)
+            if pending is None:
+                pending = torch.empty(
+                    logical_shape,
+                    dtype=loaded.dtype,
+                    device=loaded.device,
+                )
+                layer._nvfp4_pending_weight = pending
+            default_loader(pending, loaded, shard_id)
+            return
+
+        default_loader(layer.weight, loaded, shard_id)
+
+    def quantize_loaded_weight(self, layer: nn.Module, weight: torch.Tensor) -> None:
+        src = weight.detach().to(device=layer.weight.device).contiguous()
+        if src.dtype not in (torch.bfloat16, torch.float32, torch.float16):
+            src = src.to(torch.bfloat16)
+
+        if self.scale_layout == "linear":
+            packed, scale, global_scale = _quantize_nvfp4_linear(src, self.block_size)
+        elif self.scale_layout == "128x4":
+            if not src.is_cuda:
+                raise RuntimeError(
+                    "Nvfp4Spec(scale_layout='128x4') needs CUDA FlashInfer to "
+                    "quantize high-precision weights on load. Use "
+                    "scale_layout='linear' for CPU reference quantization or load "
+                    "a pre-quantized 128x4 checkpoint."
+                )
+            from flashinfer.quantization import SfLayout, nvfp4_quantize
+
+            flashinfer_global_scale = (_FP8_E4M3_AMAX * _NVFP4_MAX) / (
+                src.float().abs().amax().clamp_min(1e-12)
+            )
+            flashinfer_global_scale = flashinfer_global_scale.reshape(1)
+            if src.dtype == torch.float32:
+                src = src.to(torch.bfloat16)
+            packed, scale = nvfp4_quantize(
+                src,
+                flashinfer_global_scale,
+                sfLayout=SfLayout.layout_128x4,
+                do_shuffle=False,
+                enable_pdl=False,
+            )
+            global_scale = 1.0 / flashinfer_global_scale
+        else:
+            raise RuntimeError(
+                f"unhandled Nvfp4Spec scale_layout={self.scale_layout!r}"
+            )
+
+        layer.weight.data.copy_(packed.to(device=layer.weight.device).view(torch.uint8))
+        layer.weight_scale.data.copy_(
+            scale.to(device=layer.weight_scale.device).view(layer.weight_scale.dtype)
+        )
+        layer.weight_global_scale.data.copy_(
+            global_scale.to(device=layer.weight_global_scale.device)
+        )
+
+
+__all__ = ["Nvfp4Spec"]

--- a/phyai/tests/layers/linear/test_kernel_flashinfer.py
+++ b/phyai/tests/layers/linear/test_kernel_flashinfer.py
@@ -1,0 +1,121 @@
+"""FlashInferKernel capability tests.
+
+The capability tests only exercise Python predicates so hardware gating stays
+stable on CPU-only CI. The numeric test is CUDA-gated and compares FlashInfer's
+FP4 GEMM with an explicit dequantized reference.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from phyai.layers.linear.backend import KernelProbe
+from phyai.layers.linear.backends.flashinfer import FlashInferKernel
+from phyai.layers.quant import Nvfp4Spec
+from phyai.layers.quant.base import AllocationRequest
+from phyai.parallel.state import Mode
+from phyai.weights.shards import replicated
+
+CUDA = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _sm() -> int:
+    if not torch.cuda.is_available():
+        return 0
+    maj, mnr = torch.cuda.get_device_capability()
+    return maj * 10 + mnr
+
+
+def _probe(spec_id: str, *, M=16, N=128, K=128, sm=100) -> KernelProbe:
+    return KernelProbe(
+        spec_id=spec_id,
+        M_bucket=M.bit_length(),
+        N=N,
+        K=K,
+        in_dtype=torch.bfloat16,
+        out_dtype=torch.bfloat16,
+        sm=sm,
+        mode=Mode.EAGER,
+    )
+
+def _build_layer(spec, N, K, device, weight):
+    layer = torch.nn.Module()
+    layer.spec = spec
+
+    spec.allocate(
+        layer,
+        AllocationRequest(
+            weight_shape=(N, K),
+            logical_widths=[N],
+            device=device,
+        ),
+    )
+
+    spec.load_weight(layer, weight, None, replicated())
+    spec.process_after_loading(layer)
+    return layer
+
+
+def test_flashinfer_can_handle_nvfp4_sm100_only():
+    k = FlashInferKernel()
+    assert not k.can_handle(_probe("nvfp4_block_16_128x4", sm=90))
+    if k.can_handle(_probe("bf16", sm=100)):
+        assert k.can_handle(_probe("nvfp4_block_16_128x4", sm=100))
+
+
+def test_flashinfer_rejects_nvfp4_unaligned_k():
+    k = FlashInferKernel()
+    assert not k.can_handle(_probe("nvfp4_block_16_128x4", sm=100, K=120))
+
+
+@CUDA
+def test_flashinfer_numeric_accuracy():
+    if _sm() < 100:
+        pytest.skip(f"NVFP4 requires sm_100+ GPU")
+
+    torch.manual_seed(0)
+    k = FlashInferKernel()
+    N, K = 128, 128
+    weight = torch.randn((N, K), dtype=torch.bfloat16, device="cuda")
+    x = torch.randn((1, K), dtype=torch.bfloat16, device="cuda")
+    y_bf16 = F.linear(x, weight)
+    
+    spec = Nvfp4Spec(scale_layout="128x4")
+    layer = _build_layer(spec, N, K, "cuda", weight)
+
+    y_flashinfer = k.apply(layer, x, None)
+    
+    bf16_rel_err = (
+        y_flashinfer.float() - y_bf16.float()
+    ).norm() / y_bf16.float().norm().clamp_min(1e-8)
+    assert bf16_rel_err < 0.15, (
+        f"FlashInfer NVFP4 end-to-end relative error {bf16_rel_err:.4f} "
+        "against bf16 reference exceeds 15%"
+    )
+
+def test_flashinfer_numeric_accuracy_with_bias():
+    if _sm() < 100:
+        pytest.skip(f"NVFP4 requires sm_100+ GPU")
+
+    torch.manual_seed(0)
+    k = FlashInferKernel()
+    N, K = 128, 128
+    weight = torch.randn((N, K), dtype=torch.bfloat16, device="cuda")
+    bias = torch.randn((N,), dtype=torch.bfloat16, device="cuda")
+    x = torch.randn((1, K), dtype=torch.bfloat16, device="cuda")
+    y_bf16 = F.linear(x, weight, bias)
+    
+    spec = Nvfp4Spec(scale_layout="128x4")
+    layer = _build_layer(spec, N, K, "cuda", weight)
+
+    y_flashinfer = k.apply(layer, x, bias)
+    
+    bf16_rel_err = (
+        y_flashinfer.float() - y_bf16.float()
+    ).norm() / y_bf16.float().norm().clamp_min(1e-8)
+    assert bf16_rel_err < 0.15, (
+        f"FlashInfer NVFP4 end-to-end relative error {bf16_rel_err:.4f} "
+        "against bf16 reference exceeds 15%"
+    )

--- a/phyai/tests/layers/linear/test_kernel_torch.py
+++ b/phyai/tests/layers/linear/test_kernel_torch.py
@@ -14,8 +14,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from phyai.layers.linear.backend import Granularity, KernelProbe
-from phyai.layers.linear.backends.torch import TorchKernel, _expand_block_scale
-from phyai.layers.linear.spec import Bf16Spec, Fp8Spec
+from phyai.layers.linear.backends.torch import TorchKernel, _expand_block_scale, _unpack_e2m1
+from phyai.layers.linear.spec import Bf16Spec, Fp8Spec, Nvfp4Spec
 from phyai.layers.quant import AllocationRequest
 from phyai.parallel.state import Mode
 
@@ -96,6 +96,12 @@ def test_torch_can_handle_fp8_rejects_unaligned_K():
 def test_torch_can_handle_unknown_spec_rejects():
     k = TorchKernel()
     assert not k.can_handle(_probe("awq"))
+
+
+def test_torch_can_handle_nvfp4_linear_reference():
+    k = TorchKernel()
+    assert k.can_handle(_probe("nvfp4_block_16_linear", sm=0, N=8, K=16))
+    assert not k.can_handle(_probe("nvfp4_block_16_128x4", sm=100, N=128, K=128))
 
 
 def test_torch_supports_capture():
@@ -240,3 +246,47 @@ def test_torch_fp8_block_reference_numeric():
     # Dequant weight = 2.0 everywhere ⇒ y = (2.0 * K) broadcast
     expected = torch.full((4, N), 2.0 * K, dtype=torch.bfloat16)
     torch.testing.assert_close(y, expected, atol=0.5, rtol=0.01)
+
+
+# ---------------------------------------------------------------------------
+# nvfp4 reference path — dequant + F.linear
+# ---------------------------------------------------------------------------
+
+
+def test_unpack_e2m1_values():
+    packed = torch.tensor([[0x21, 0xB7]], dtype=torch.uint8)
+    out = _unpack_e2m1(packed)
+    expected = torch.tensor([[0.5, 1.0, 6.0, -1.5]], dtype=torch.float32)
+    torch.testing.assert_close(out, expected)
+
+
+def test_torch_nvfp4_reference_numeric():
+    N, K = 2, 16
+    spec = Nvfp4Spec(scale_layout="linear")
+    layer = _build_layer(spec, N=N, K=K, device="cpu")
+    # Low nibble then high nibble: both 0x2 encode E2M1 value 1.0.
+    layer.weight.data = torch.full((N, K // 2), 0x22, dtype=torch.uint8)
+    layer.weight_scale.data = torch.ones(N, K // 16, dtype=torch.float8_e4m3fn)
+    layer.weight_global_scale.data.fill_(2.0)
+
+    x = torch.ones(3, K, dtype=torch.bfloat16)
+    y = TorchKernel().apply(layer, x, None)
+    expected = torch.full((3, N), 2.0 * K, dtype=torch.bfloat16)
+    torch.testing.assert_close(y, expected, atol=0.5, rtol=0.01)
+
+
+def test_torch_nvfp4_linear_quantized_random_accuracy():
+    torch.manual_seed(0)
+    N, K = 64, 128
+    spec = Nvfp4Spec(scale_layout="linear")
+    layer = _build_layer(spec, N=N, K=K, device="cpu")
+
+    weight = torch.randn(N, K, dtype=torch.bfloat16)
+    spec.quantize_loaded_weight(layer, weight)
+
+    x = torch.randn(8, K, dtype=torch.bfloat16)
+    y = TorchKernel().apply(layer, x, None)
+    ref = F.linear(x, weight)
+
+    rel_err = (y.float() - ref.float()).norm() / ref.float().norm().clamp_min(1e-8)
+    assert rel_err < 0.1, f"NVFP4 linear-layout rel_err={rel_err.item():.4f}"

--- a/phyai/tests/layers/linear/test_layers.py
+++ b/phyai/tests/layers/linear/test_layers.py
@@ -403,6 +403,26 @@ def test_replicated_linear_attaches(fake_mesh):
     assert layer.bias.hf_keys == [("block.fc.bias", None)]
 
 
+def test_replicated_linear_nvfp4_loader_quantizes_bf16_weight(fake_mesh):
+    fake_mesh()
+    _init_default_dispatcher()
+    layer = L.ReplicatedLinear(
+        in_features=16,
+        out_features=8,
+        bias=False,
+        spec=L.Nvfp4Spec(scale_layout="linear"),
+        prefix="block.fc",
+    )
+
+    disk = torch.ones(8, 16, dtype=torch.bfloat16)
+    layer.weight.weight_loader(layer.weight, disk, None)
+    assert layer._nvfp4_pending_weight.shape == disk.shape
+    layer.post_load()
+    assert layer.weight.shape == (8, 8)
+    assert layer.weight.dtype == torch.uint8
+    assert layer._nvfp4_pending_weight is None
+
+
 def test_column_parallel_attaches_tp2_rank1(fake_mesh):
     fake_mesh(sizes={"tp": 2}, ranks={"tp": 1})
     _init_default_dispatcher()
@@ -502,7 +522,7 @@ def test_init_force_env_overrides(fake_mesh, monkeypatch):
         (86, ["bf16"]),  # Ampere A10/A40 — the reported failure
         (89, ["bf16", "fp8_per_tensor", "fp8_per_channel"]),  # Ada
         (90, ["bf16", "fp8_per_tensor", "fp8_per_channel"]),  # Hopper
-        (100, ["bf16", "fp8_per_tensor", "fp8_per_channel", "fp8_block_128_128"]),
+        (100,["bf16", "fp8_per_tensor", "fp8_per_channel", "fp8_block_128_128", "nvfp4_block_16_128x4",]),
     ],
 )
 def test_supported_specs_for_sm(sm, expected):

--- a/phyai/tests/layers/linear/test_spec.py
+++ b/phyai/tests/layers/linear/test_spec.py
@@ -9,14 +9,17 @@ import pytest
 import torch
 import torch.nn as nn
 
+from phyai.layers.linear.backends.torch import _dequant_nvfp4_weight
 from phyai.layers.quant import (
     ActivationView,
     AllocationRequest,
     Bf16Spec,
     Fp8Spec,
     Granularity,
+    Nvfp4Spec,
 )
 from phyai.layers.quant.fp8 import _convert_to_channelwise
+from phyai.layers.quant.nvfp4 import _quantize_nvfp4_linear
 
 
 # ---------------------------------------------------------------------------
@@ -202,3 +205,83 @@ def test_fp8_spec_id_format():
         Fp8Spec(granularity=Granularity.BLOCK, block_shape=(64, 256)).spec_id
         == "fp8_block_64_256"
     )
+
+
+# ---------------------------------------------------------------------------
+# Nvfp4Spec
+# ---------------------------------------------------------------------------
+
+
+def test_nvfp4_linear_shapes():
+    spec = Nvfp4Spec(scale_layout="linear")
+    layer = nn.Module()
+    spec.allocate(layer, _request(weight_shape=(128, 64)))
+    assert layer.weight.shape == (128, 32)
+    assert layer.weight.dtype == torch.uint8
+    assert layer.weight_scale.shape == (128, 4)
+    assert layer.weight_scale.dtype == torch.float8_e4m3fn
+    assert layer.weight_global_scale.shape == (1,)
+    assert spec.spec_id == "nvfp4_block_16_linear"
+
+
+def test_nvfp4_128x4_scale_shape_pads():
+    spec = Nvfp4Spec(scale_layout="128x4")
+    layer = nn.Module()
+    spec.allocate(layer, _request(weight_shape=(129, 80)))
+    assert layer.weight.shape == (129, 40)
+    # N padded to 256; K/16=5 padded to 8.
+    assert layer.weight_scale.shape == (256, 8)
+    assert spec.spec_id == "nvfp4_block_16_128x4"
+
+
+def test_nvfp4_enforces_k_divisible_by_16():
+    spec = Nvfp4Spec()
+    layer = nn.Module()
+    with pytest.raises(ValueError, match="not divisible"):
+        spec.allocate(layer, _request(weight_shape=(64, 60)))
+
+
+def test_nvfp4_rejects_non_2d_shape():
+    spec = Nvfp4Spec()
+    layer = nn.Module()
+    with pytest.raises(ValueError, match="2-D weight_shape"):
+        spec.allocate(
+            layer,
+            AllocationRequest(
+                weight_shape=(8, 16, 32),
+                logical_widths=[8],
+            ),
+        )
+
+
+def test_nvfp4_rejects_nonstandard_block_size():
+    with pytest.raises(ValueError, match="block_size=16"):
+        Nvfp4Spec(block_size=32)
+
+
+def test_nvfp4_quantize_loaded_weight_linear_layout():
+    spec = Nvfp4Spec(scale_layout="linear")
+    layer = nn.Module()
+    spec.allocate(layer, _request(weight_shape=(2, 16)))
+    weight = torch.ones(2, 16, dtype=torch.bfloat16)
+
+    spec.quantize_loaded_weight(layer, weight)
+
+    torch.testing.assert_close(
+        _dequant_nvfp4_weight(layer),
+        weight.float(),
+        atol=0.05,
+        rtol=0.05,
+    )
+    assert layer.weight_scale.shape == (2, 1)
+    assert layer.weight_global_scale.shape == (1,)
+
+
+def test_quantize_nvfp4_linear_round_trips_simple_values():
+    weight = torch.ones(2, 16, dtype=torch.bfloat16)
+    packed, scale, global_scale = _quantize_nvfp4_linear(weight, 16)
+    assert packed.shape == (2, 8)
+    assert packed.dtype == torch.uint8
+    assert scale.shape == (2, 1)
+    assert scale.dtype == torch.float8_e4m3fn
+    assert global_scale.shape == (1,)


### PR DESCRIPTION
Resolevs #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 support for linear layers on supported GPUs, including a new quantization and execution path.
  * Expanded supported hardware checks so newer GPUs can use the additional NVFP4 option.
  * Improved weight loading to better handle spec-specific scaling and packed weights during model setup.

* **Bug Fixes**
  * Added validation for unsupported NVFP4 shapes and configurations, helping catch invalid setups earlier.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->