### PR TITLE
feat(phyai): Support gr00t

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ CPU is the default for tests — `phyai/tests/conftest.py` autouses a fixture th
 - Using ENGLISH for comment.
 - Be aware that phyai is a general inference engine for physical AI. Do not modify general components(such as phyai.layers, phyai.runtime) in phyai when supporting new models. Unless lack of layers, or lack of phyai's system components. Modify phyai's general components is a big deal, you should tell user first, let them agree.
 - When user want you to commit to github. You should run pre-commit first.
+- After an agent modifies code, it must run `scripts/run_pre_commit.sh` before handing off or committing. If `pre-commit` is not installed, follow the installation commands in `scripts/setup_dev_env.sh`.
 - using `flashinfer` by default if CP is not set. When CP is set, pls using `MagiAttention` whose github repo is https://github.com/SandAI-org/MagiAttention.
 - Eager Attention is just for debug only, u should use flashinfer/flash attn/sdpa. and in most of the time, debug mode also need use flashinfer/flash attn/sdpa at first.
 - When a user asks you to run a model in FP32 precision, double-check first. Most common models are trained in BF16/FP16/FP8/NVFP4 rather than FP32. Ask the user why they need FP32 precision before proceeding. (Exception: ViT, time-embedding MLPs — some models do use FP32 for these two modules.)

--- a/phyai-utils-tools/pyproject.toml
+++ b/phyai-utils-tools/pyproject.toml
@@ -7,9 +7,16 @@ dependencies = [
     "av>=14.0.0",
     "huggingface-hub",
     "numpy",
+    "pillow",
     "torch==2.11",
+    "torchvision",
     "transformers==5.8.1",
 ]
+
+[project.optional-dependencies]
+# fastokens accelerates phyai_utils_tools.tokenizer (moved here with the
+# processors; the engine no longer tokenizes).
+fastokenizer = ["fastokens>=0.2.0"]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/phyai-utils-tools/pyproject.toml
+++ b/phyai-utils-tools/pyproject.toml
@@ -14,8 +14,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# fastokens accelerates phyai_utils_tools.tokenizer (moved here with the
-# processors; the engine no longer tokenizes).
+# fastokens accelerates phyai_utils_tools.tokenizer and processor utilities.
 fastokenizer = ["fastokens>=0.2.0"]
 
 [build-system]

--- a/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/__init__.py
+++ b/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/__init__.py
@@ -1,0 +1,23 @@
+"""GR00T-N1.7 processor."""
+
+from __future__ import annotations
+
+from phyai_utils_tools.models.gr00t.processor_gr00t import (
+    GR00TActionConfig,
+    GR00TModalityConfig,
+    GR00TObservation,
+    GR00TProcessedInputs,
+    GR00TProcessor,
+    ensure_numpy_observation,
+    parse_modality_configs,
+)
+
+__all__ = [
+    "GR00TActionConfig",
+    "GR00TModalityConfig",
+    "GR00TObservation",
+    "GR00TProcessedInputs",
+    "GR00TProcessor",
+    "ensure_numpy_observation",
+    "parse_modality_configs",
+]

--- a/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/ops_gr00t.py
+++ b/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/ops_gr00t.py
@@ -1,0 +1,586 @@
+"""GR00T-N1.7 processor ops — pure, dependency-light transforms.
+
+Verbatim port of the deterministic eval image transform, the native Qwen3-VL
+image preprocessing (``smart_resize`` + patchify), and the state/action
+normalization math from phyai's in-engine ``processor_gr00t_n17``. These are
+plain functions over numpy / torch / PIL with **no ``phyai`` dependency**, so the
+package stays a workspace leaf.
+
+The image-transform helpers take explicit size/crop primitives instead of a
+processor object, so they are reusable and trivially testable.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+import torch
+
+
+# Checkpoint embodiment-tag aliases -> canonical lowercase value.
+EMBODIMENT_NAME_TO_VALUE: dict[str, str] = {
+    "OXE_DROID_RELATIVE_EEF_RELATIVE_JOINT": "oxe_droid_relative_eef_relative_joint",
+    "XDOF": "xdof_relative_eef_relative_joint",
+    "XDOF_SUBTASK": "xdof_relative_eef_relative_joint_subtask",
+    "REAL_G1": "real_g1_relative_eef_relative_joints",
+    "REAL_R1_PRO_SHARPA": "real_r1_pro_sharpa_relative_eef",
+    "REAL_R1_PRO_SHARPA_HUMAN": "real_r1_pro_sharpa_relative_eef_human",
+    "REAL_R1_PRO_SHARPA_MAXINSIGHTS": "real_r1_pro_sharpa_relative_eef_maxinsights",
+    "REAL_R1_PRO_SHARPA_MECKA": "real_r1_pro_sharpa_relative_eef_mecka",
+    "UNITREE_G1": "unitree_g1_full_body_with_waist_height_nav_cmd",
+    "UNITREE_G1_SONIC": "unitree_g1_sonic",
+    "SIMPLER_ENV_GOOGLE": "simpler_env_google",
+    "SIMPLER_ENV_WIDOWX": "simpler_env_widowx",
+    "LIBERO_PANDA": "libero_sim",
+    "NEW_EMBODIMENT": "new_embodiment",
+    "ROBOCASA_GR1_TABLETOP": "robocasa_gr1_tabletop",
+    "ROBOCASA_PANDA_OMRON": "robocasa_panda_omron",
+}
+
+
+# Canonical embodiment value -> action-head projector slot.
+DEFAULT_EMBODIMENT_ID_MAPPING: dict[str, int] = {
+    "oxe_droid_relative_eef_relative_joint": 24,
+    "xdof_relative_eef_relative_joint": 27,
+    "xdof_relative_eef_relative_joint_subtask": 27,
+    "real_g1_relative_eef_relative_joints": 25,
+    "real_r1_pro_sharpa_relative_eef": 26,
+    "real_r1_pro_sharpa_relative_eef_human": 26,
+    "real_r1_pro_sharpa_relative_eef_maxinsights": 26,
+    "real_r1_pro_sharpa_relative_eef_mecka": 26,
+    "unitree_g1_full_body_with_waist_height_nav_cmd": 25,
+    "unitree_g1_sonic": 11,
+    "simpler_env_google": 0,
+    "simpler_env_widowx": 1,
+    "libero_sim": 2,
+    "new_embodiment": 10,
+    "robocasa_panda_omron": 10,
+    "robocasa_gr1_tabletop": 10,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Small parsing / loading helpers                                             #
+# --------------------------------------------------------------------------- #
+
+
+def resolve_embodiment_tag(tag: str) -> str:
+    """Map a user embodiment tag to its canonical lowercase value."""
+    if not tag:
+        raise ValueError("embodiment_tag must be a non-empty string.")
+    stripped = tag.strip()
+    upper = stripped.upper()
+    if upper in EMBODIMENT_NAME_TO_VALUE:
+        return EMBODIMENT_NAME_TO_VALUE[upper]
+    lower = stripped.lower()
+    for value in EMBODIMENT_NAME_TO_VALUE.values():
+        if value.lower() == lower:
+            return value
+    return lower
+
+
+def tuple2(v: list[int] | tuple[int, int] | None) -> tuple[int, int] | None:
+    """Coerce a length-2 sequence to an ``(int, int)`` tuple (or ``None``)."""
+    if v is None:
+        return None
+    if len(v) != 2:
+        raise ValueError(f"expected 2 values, got {v!r}.")
+    return (int(v[0]), int(v[1]))
+
+
+def enum_value(value: Any) -> str:
+    """Lowercase the trailing token of an enum-ish string (``A.B`` -> ``b``)."""
+    text = str(value)
+    if "." in text:
+        text = text.rsplit(".", 1)[-1]
+    return text.lower()
+
+
+def load_json(path: Path) -> Any:
+    """Read and parse a JSON file."""
+    with path.open("r") as f:
+        return json.load(f)
+
+
+def load_preprocessor_config(
+    model_name_or_path: str, *, local_files_only: bool = False
+) -> dict[str, Any] | None:
+    """Load ``preprocessor_config.json`` from a local dir or the hub cache.
+
+    Returns ``None`` when it cannot be resolved (callers fall back to
+    Cosmos-Reason2 defaults). Uses ``huggingface_hub`` for cache resolution —
+    no ``transformers`` processor machinery.
+    """
+    local = Path(model_name_or_path)
+    if local.is_dir():
+        candidate = local / "preprocessor_config.json"
+        return load_json(candidate) if candidate.is_file() else None
+    try:
+        from huggingface_hub import hf_hub_download
+
+        path = hf_hub_download(
+            model_name_or_path,
+            "preprocessor_config.json",
+            local_files_only=local_files_only,
+        )
+    except Exception:
+        return None
+    return load_json(Path(path))
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic eval image transform (-> CHW uint8)                           #
+# --------------------------------------------------------------------------- #
+
+
+def eval_transform_image(
+    image: np.ndarray,
+    *,
+    shortest_image_edge: int | None,
+    image_target_size: tuple[int, int] | None,
+    image_crop_size: tuple[int, int] | None,
+    crop_fraction: float | None,
+) -> np.ndarray:
+    """Deterministic GR00T eval image transform returning CHW uint8.
+
+    Prefers the cv2 path (matches the official transform); falls back to PIL
+    when OpenCV is unavailable.
+    """
+    if image.dtype != np.uint8:
+        raise TypeError(f"image must be uint8, got {image.dtype}.")
+    transformed = _eval_transform_image_cv2(
+        image,
+        shortest_image_edge=shortest_image_edge,
+        image_target_size=image_target_size,
+        image_crop_size=image_crop_size,
+        crop_fraction=crop_fraction,
+    )
+    if transformed is not None:
+        return transformed
+    pil = Image.fromarray(image)
+    pil = _letterbox_pad_pil(pil)
+    max_size = _resolve_max_size(shortest_image_edge, image_target_size)
+    pil = _resize_shortest_edge(pil, max_size)
+    fraction = _resolve_crop_fraction(crop_fraction, image_crop_size, image_target_size)
+    pil = _fractional_center_crop(pil, float(fraction))
+    pil = _resize_shortest_edge(pil, max_size)
+    arr = np.asarray(pil, dtype=np.uint8)
+    return np.transpose(arr, (2, 0, 1))
+
+
+def _resolve_max_size(
+    shortest_image_edge: int | None, image_target_size: tuple[int, int] | None
+) -> int:
+    if shortest_image_edge is not None:
+        return int(shortest_image_edge)
+    if image_target_size is None:
+        raise ValueError(
+            "image_target_size is required when shortest_image_edge is None."
+        )
+    return int(image_target_size[0])
+
+
+def _resolve_crop_fraction(
+    crop_fraction: float | None,
+    image_crop_size: tuple[int, int] | None,
+    image_target_size: tuple[int, int] | None,
+) -> float:
+    if crop_fraction is not None:
+        return float(crop_fraction)
+    if image_crop_size is None or image_target_size is None:
+        raise ValueError(
+            "image_crop_size/image_target_size required when crop_fraction is None."
+        )
+    return image_crop_size[0] / image_target_size[0]
+
+
+def _eval_transform_image_cv2(
+    image: np.ndarray,
+    *,
+    shortest_image_edge: int | None,
+    image_target_size: tuple[int, int] | None,
+    image_crop_size: tuple[int, int] | None,
+    crop_fraction: float | None,
+) -> np.ndarray | None:
+    try:
+        import cv2
+    except ImportError:
+        return None
+    image = _letterbox_pad_cv2(image, cv2)
+    max_size = _resolve_max_size(shortest_image_edge, image_target_size)
+    image = _resize_shortest_edge_cv2(image, int(max_size), cv2)
+    fraction = _resolve_crop_fraction(crop_fraction, image_crop_size, image_target_size)
+    image = _fractional_center_crop_np(image, float(fraction))
+    image = _resize_shortest_edge_cv2(image, int(max_size), cv2)
+    return np.transpose(np.asarray(image, dtype=np.uint8), (2, 0, 1))
+
+
+def _letterbox_pad_cv2(image: np.ndarray, cv2: Any) -> np.ndarray:
+    height, width = image.shape[:2]
+    if height == width:
+        return image
+    max_dim = max(height, width)
+    pad_h = max_dim - height
+    pad_w = max_dim - width
+    return cv2.copyMakeBorder(
+        image,
+        pad_h // 2,
+        pad_h - pad_h // 2,
+        pad_w // 2,
+        pad_w - pad_w // 2,
+        cv2.BORDER_CONSTANT,
+        value=0,
+    )
+
+
+def _resize_shortest_edge_cv2(image: np.ndarray, max_size: int, cv2: Any) -> np.ndarray:
+    height, width = image.shape[:2]
+    shortest = min(height, width)
+    if shortest == max_size:
+        return image
+    scale = max_size / shortest
+    new_width = int(round(width * scale))
+    new_height = int(round(height * scale))
+    return cv2.resize(
+        image,
+        (new_width, new_height),
+        interpolation=cv2.INTER_AREA,
+    )
+
+
+def _fractional_center_crop_np(image: np.ndarray, crop_fraction: float) -> np.ndarray:
+    if not 0.0 < crop_fraction <= 1.0:
+        raise ValueError("crop_fraction must be in (0, 1].")
+    height, width = image.shape[:2]
+    crop_height = max(1, int(height * crop_fraction))
+    crop_width = max(1, int(width * crop_fraction))
+    top = (height - crop_height) // 2
+    left = (width - crop_width) // 2
+    return image[top : top + crop_height, left : left + crop_width]
+
+
+def _letterbox_pad_pil(image: Image.Image) -> Image.Image:
+    width, height = image.size
+    if width == height:
+        return image
+    max_dim = max(width, height)
+    out = Image.new("RGB", (max_dim, max_dim), color=(0, 0, 0))
+    out.paste(image, ((max_dim - width) // 2, (max_dim - height) // 2))
+    return out
+
+
+def _resize_shortest_edge(image: Image.Image, max_size: int) -> Image.Image:
+    width, height = image.size
+    shortest = min(width, height)
+    if shortest == max_size:
+        return image
+    scale = max_size / shortest
+    new_size = (int(round(width * scale)), int(round(height * scale)))
+    return image.resize(new_size, resample=Image.Resampling.BOX)
+
+
+def _fractional_center_crop(image: Image.Image, crop_fraction: float) -> Image.Image:
+    if not 0.0 < crop_fraction <= 1.0:
+        raise ValueError("crop_fraction must be in (0, 1].")
+    width, height = image.size
+    crop_width = max(1, int(width * crop_fraction))
+    crop_height = max(1, int(height * crop_fraction))
+    left = (width - crop_width) // 2
+    top = (height - crop_height) // 2
+    return image.crop((left, top, left + crop_width, top + crop_height))
+
+
+# --------------------------------------------------------------------------- #
+# Native Qwen3-VL image preprocessing                                         #
+# --------------------------------------------------------------------------- #
+
+
+def qwen3vl_smart_resize(
+    height: int, width: int, *, factor: int, min_pixels: int, max_pixels: int
+) -> tuple[int, int]:
+    """Qwen2/3-VL ``smart_resize`` — verbatim from the transformers source.
+
+    Rounds H/W to multiples of ``factor`` while keeping the pixel count in
+    ``[min_pixels, max_pixels]`` and the aspect ratio as close as possible.
+    """
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError(
+            "absolute aspect ratio must be smaller than 200, got "
+            f"{max(height, width) / min(height, width)}."
+        )
+    h_bar = round(height / factor) * factor
+    w_bar = round(width / factor) * factor
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = max(factor, math.floor(height / beta / factor) * factor)
+        w_bar = max(factor, math.floor(width / beta / factor) * factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = math.ceil(height * beta / factor) * factor
+        w_bar = math.ceil(width * beta / factor) * factor
+    return h_bar, w_bar
+
+
+def qwen3vl_process_image(
+    image_chw: np.ndarray, params: dict[str, Any]
+) -> tuple[torch.Tensor, tuple[int, int, int]]:
+    """Native Qwen2-VL image processor for one CHW ``uint8`` image.
+
+    Reproduces ``Qwen2VLImageProcessor._preprocess`` for a single image
+    (``grid_t = 1``, temporal axis filled by repeating the frame): resize to a
+    ``smart_resize`` grid (BICUBIC, no-op when already aligned), rescale to
+    ``[0, 1]``, normalize with ``image_mean``/``image_std``, then reshape /
+    permute into flattened patches.
+
+    Returns ``(pixel_values, (grid_t, grid_h, grid_w))`` where ``pixel_values``
+    is ``(grid_t*grid_h*grid_w, C*temporal*patch*patch)``.
+    """
+    patch_size = int(params["patch_size"])
+    temporal = int(params["temporal_patch_size"])
+    merge = int(params["merge_size"])
+    factor = patch_size * merge
+
+    tensor = torch.from_numpy(np.ascontiguousarray(image_chw)).to(torch.float32)
+    if tensor.ndim != 3:
+        raise ValueError(f"expected CHW image, got shape {tuple(tensor.shape)}.")
+    channels, height, width = tensor.shape
+    resized_h, resized_w = qwen3vl_smart_resize(
+        height,
+        width,
+        factor=factor,
+        min_pixels=int(params["min_pixels"]),
+        max_pixels=int(params["max_pixels"]),
+    )
+    if (resized_h, resized_w) != (height, width):
+        from torchvision.transforms import functional as tvf
+
+        tensor = tvf.resize(
+            tensor,
+            [resized_h, resized_w],
+            interpolation=tvf.InterpolationMode.BICUBIC,
+            antialias=True,
+        )
+
+    tensor = tensor / 255.0
+    mean = torch.tensor(params["image_mean"], dtype=torch.float32).view(channels, 1, 1)
+    std = torch.tensor(params["image_std"], dtype=torch.float32).view(channels, 1, 1)
+    tensor = (tensor - mean) / std
+
+    grid_h = resized_h // patch_size
+    grid_w = resized_w // patch_size
+    patches = tensor.reshape(
+        1,
+        channels,
+        grid_h // merge,
+        merge,
+        patch_size,
+        grid_w // merge,
+        merge,
+        patch_size,
+    )
+    patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+    flatten_patches = (
+        patches.unsqueeze(6)
+        .expand(-1, -1, -1, -1, -1, -1, temporal, -1, -1)
+        .reshape(grid_h * grid_w, channels * temporal * patch_size * patch_size)
+    )
+    return flatten_patches.contiguous(), (1, int(grid_h), int(grid_w))
+
+
+# --------------------------------------------------------------------------- #
+# State / action normalization math                                          #
+# --------------------------------------------------------------------------- #
+
+
+def apply_sin_cos_encoding(values: np.ndarray) -> np.ndarray:
+    """Concatenate ``[sin(values), cos(values)]`` along the last axis."""
+    return np.concatenate([np.sin(values), np.cos(values)], axis=-1)
+
+
+def normalize_values_minmax(values: np.ndarray, params: dict[str, np.ndarray]) -> np.ndarray:
+    """Min-max normalize to ``[-1, 1]`` (degenerate dims map to 0)."""
+    min_vals = params["min"]
+    max_vals = params["max"]
+    normalized = np.zeros_like(values)
+    mask = ~np.isclose(max_vals, min_vals)
+    normalized[..., mask] = (values[..., mask] - min_vals[..., mask]) / (
+        max_vals[..., mask] - min_vals[..., mask]
+    )
+    normalized[..., mask] = 2 * normalized[..., mask] - 1
+    return normalized
+
+
+def unnormalize_values_minmax(
+    normalized_values: np.ndarray, params: dict[str, np.ndarray]
+) -> np.ndarray:
+    """Invert :func:`normalize_values_minmax` (clips to ``[-1, 1]`` first)."""
+    min_vals = params["min"]
+    max_vals = params["max"]
+    return (np.clip(normalized_values, -1.0, 1.0) + 1.0) / 2.0 * (
+        max_vals - min_vals
+    ) + min_vals
+
+
+def normalize_values_meanstd(values: np.ndarray, params: dict[str, np.ndarray]) -> np.ndarray:
+    """Mean-std normalize (zero-std dims pass through unchanged)."""
+    mean_vals = params["mean"]
+    std_vals = params["std"]
+    normalized = np.zeros_like(values)
+    mask = std_vals != 0
+    normalized[..., mask] = (values[..., mask] - mean_vals[..., mask]) / std_vals[
+        ..., mask
+    ]
+    normalized[..., ~mask] = values[..., ~mask]
+    return normalized
+
+
+def unnormalize_values_meanstd(
+    normalized_values: np.ndarray, params: dict[str, np.ndarray]
+) -> np.ndarray:
+    """Invert :func:`normalize_values_meanstd`."""
+    mean_vals = params["mean"]
+    std_vals = params["std"]
+    unnormalized = np.zeros_like(normalized_values)
+    mask = std_vals != 0
+    unnormalized[..., mask] = normalized_values[..., mask] * std_vals[
+        ..., mask
+    ] + mean_vals[..., mask]
+    unnormalized[..., ~mask] = normalized_values[..., ~mask]
+    return unnormalized
+
+
+def relative_non_eef_to_absolute(
+    relative_action: np.ndarray, reference_state: np.ndarray
+) -> np.ndarray:
+    """Add the last reference state to a relative (non-EEF) action chunk."""
+    is_batched = relative_action.ndim == 3
+    rel = relative_action if is_batched else relative_action[None]
+    state = reference_state
+    if state.ndim == 2:
+        state = state[None]
+    refs = state[:, -1, :]
+    absolute = rel + refs[:, None, :]
+    return absolute if is_batched else absolute[0]
+
+
+def _normalize_vector(vector: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(vector)
+    if norm < 1e-12:
+        raise ValueError("Cannot normalize a near-zero rotation vector.")
+    return vector / norm
+
+
+def rot6d_to_matrix(rot6d: np.ndarray) -> np.ndarray:
+    """Convert GR00T's row-major 6D rotation representation to a matrix.
+
+    Matches Isaac-GR00T's ``EndEffectorPose._rot6d_to_matrix`` convention: the
+    6D vector stores the first two **rows** of the rotation matrix, then uses
+    Gram-Schmidt to recover an orthonormal frame.
+    """
+    rows = np.asarray(rot6d, dtype=np.float64).reshape(2, 3)
+    row1 = _normalize_vector(rows[0])
+    row2 = rows[1] - np.dot(row1, rows[1]) * row1
+    row2 = _normalize_vector(row2)
+    row3 = np.cross(row1, row2)
+    return np.vstack([row1, row2, row3])
+
+
+def matrix_to_rot6d(rotation_matrix: np.ndarray) -> np.ndarray:
+    """Convert a rotation matrix to GR00T's row-major 6D representation."""
+    return np.asarray(rotation_matrix, dtype=np.float64)[:2, :].reshape(6)
+
+
+def xyz_rot6d_to_homogeneous(action: np.ndarray) -> np.ndarray:
+    """Convert one ``XYZ_ROT6D`` action row to a homogeneous transform."""
+    values = np.asarray(action, dtype=np.float64)
+    if values.shape != (9,):
+        raise ValueError(f"XYZ_ROT6D action must have shape (9,), got {values.shape}.")
+    transform = np.eye(4, dtype=np.float64)
+    transform[:3, :3] = rot6d_to_matrix(values[3:])
+    transform[:3, 3] = values[:3]
+    return transform
+
+
+def homogeneous_to_xyz_rot6d(transform: np.ndarray) -> np.ndarray:
+    """Convert one homogeneous transform to an ``XYZ_ROT6D`` action row."""
+    matrix = np.asarray(transform, dtype=np.float64)
+    if matrix.shape != (4, 4):
+        raise ValueError(
+            f"homogeneous transform must have shape (4, 4), got {matrix.shape}."
+        )
+    return np.concatenate([matrix[:3, 3], matrix_to_rot6d(matrix[:3, :3])])
+
+
+def relative_eef_to_absolute(
+    relative_action: np.ndarray,
+    reference_state: np.ndarray,
+    *,
+    action_format: str,
+) -> np.ndarray:
+    """Compose relative EEF actions with the last reference EEF state.
+
+    For ``XYZ_ROT6D``, this mirrors Isaac-GR00T's
+    ``EndEffectorActionChunk.to_absolute_chunking``:
+    ``T_absolute = T_reference @ T_relative`` for every action in the chunk.
+    """
+    if action_format.lower() != "xyz_rot6d":
+        raise NotImplementedError(
+            f"Relative EEF decode currently supports XYZ_ROT6D, got {action_format!r}."
+        )
+
+    is_batched = relative_action.ndim == 3
+    rel = relative_action if is_batched else relative_action[None]
+    state = reference_state
+    if state.ndim == 2:
+        state = state[None]
+    if rel.ndim != 3 or state.ndim != 3:
+        raise ValueError(
+            "relative EEF action/state must have shapes (B,T,D)/(B,S,D) "
+            f"or (T,D)/(S,D), got {relative_action.shape} and {reference_state.shape}."
+        )
+    if rel.shape[-1] != 9 or state.shape[-1] != 9:
+        raise ValueError(
+            "XYZ_ROT6D relative EEF action/state require last dimension 9, got "
+            f"{rel.shape[-1]} and {state.shape[-1]}."
+        )
+
+    outputs = []
+    for rel_batch, state_batch in zip(rel, state):
+        reference = xyz_rot6d_to_homogeneous(state_batch[-1])
+        rows = []
+        for rel_row in rel_batch:
+            absolute = reference @ xyz_rot6d_to_homogeneous(rel_row)
+            rows.append(homogeneous_to_xyz_rot6d(absolute))
+        outputs.append(np.stack(rows, axis=0))
+    absolute = np.stack(outputs, axis=0).astype(np.float32, copy=False)
+    return absolute if is_batched else absolute[0]
+
+
+__all__ = [
+    "DEFAULT_EMBODIMENT_ID_MAPPING",
+    "EMBODIMENT_NAME_TO_VALUE",
+    "apply_sin_cos_encoding",
+    "enum_value",
+    "eval_transform_image",
+    "load_json",
+    "load_preprocessor_config",
+    "normalize_values_meanstd",
+    "normalize_values_minmax",
+    "homogeneous_to_xyz_rot6d",
+    "matrix_to_rot6d",
+    "qwen3vl_process_image",
+    "qwen3vl_smart_resize",
+    "relative_eef_to_absolute",
+    "relative_non_eef_to_absolute",
+    "resolve_embodiment_tag",
+    "rot6d_to_matrix",
+    "tuple2",
+    "unnormalize_values_meanstd",
+    "unnormalize_values_minmax",
+    "xyz_rot6d_to_homogeneous",
+]

--- a/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/ops_gr00t.py
+++ b/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/ops_gr00t.py
@@ -408,7 +408,7 @@ def normalize_values_minmax(
     """Min-max normalize to ``[-1, 1]`` (degenerate dims map to 0)."""
     min_vals = params["min"]
     max_vals = params["max"]
-    normalized = np.zeros_like(values)
+    normalized = np.zeros(values.shape, dtype=np.result_type(values.dtype, np.float32))
     mask = ~np.isclose(max_vals, min_vals)
     normalized[..., mask] = (values[..., mask] - min_vals[..., mask]) / (
         max_vals[..., mask] - min_vals[..., mask]
@@ -434,7 +434,7 @@ def normalize_values_meanstd(
     """Mean-std normalize (zero-std dims pass through unchanged)."""
     mean_vals = params["mean"]
     std_vals = params["std"]
-    normalized = np.zeros_like(values)
+    normalized = np.zeros(values.shape, dtype=np.result_type(values.dtype, np.float32))
     mask = std_vals != 0
     normalized[..., mask] = (values[..., mask] - mean_vals[..., mask]) / std_vals[
         ..., mask
@@ -449,7 +449,9 @@ def unnormalize_values_meanstd(
     """Invert :func:`normalize_values_meanstd`."""
     mean_vals = params["mean"]
     std_vals = params["std"]
-    unnormalized = np.zeros_like(normalized_values)
+    unnormalized = np.zeros(
+        normalized_values.shape, dtype=np.result_type(normalized_values.dtype, np.float32)
+    )
     mask = std_vals != 0
     unnormalized[..., mask] = (
         normalized_values[..., mask] * std_vals[..., mask] + mean_vals[..., mask]
@@ -467,6 +469,16 @@ def relative_non_eef_to_absolute(
     state = reference_state
     if state.ndim == 2:
         state = state[None]
+    if rel.ndim != 3 or state.ndim != 3:
+        raise ValueError(
+            "relative action/state must have shapes (B,T,D)/(B,S,D) "
+            f"or (T,D)/(S,D), got {relative_action.shape} and {reference_state.shape}."
+        )
+    if rel.shape[0] != state.shape[0]:
+        raise ValueError(
+            f"Batch dimension mismatch: relative_action has batch size {rel.shape[0]}, "
+            f"but reference_state has batch size {state.shape[0]}."
+        )
     refs = state[:, -1, :]
     absolute = rel + refs[:, None, :]
     return absolute if is_batched else absolute[0]
@@ -546,6 +558,11 @@ def relative_eef_to_absolute(
         raise ValueError(
             "relative EEF action/state must have shapes (B,T,D)/(B,S,D) "
             f"or (T,D)/(S,D), got {relative_action.shape} and {reference_state.shape}."
+        )
+    if rel.shape[0] != state.shape[0]:
+        raise ValueError(
+            f"Batch dimension mismatch: relative_action has batch size {rel.shape[0]}, "
+            f"but reference_state has batch size {state.shape[0]}."
         )
     if rel.shape[-1] != 9 or state.shape[-1] != 9:
         raise ValueError(

--- a/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/ops_gr00t.py
+++ b/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/ops_gr00t.py
@@ -402,7 +402,9 @@ def apply_sin_cos_encoding(values: np.ndarray) -> np.ndarray:
     return np.concatenate([np.sin(values), np.cos(values)], axis=-1)
 
 
-def normalize_values_minmax(values: np.ndarray, params: dict[str, np.ndarray]) -> np.ndarray:
+def normalize_values_minmax(
+    values: np.ndarray, params: dict[str, np.ndarray]
+) -> np.ndarray:
     """Min-max normalize to ``[-1, 1]`` (degenerate dims map to 0)."""
     min_vals = params["min"]
     max_vals = params["max"]
@@ -426,7 +428,9 @@ def unnormalize_values_minmax(
     ) + min_vals
 
 
-def normalize_values_meanstd(values: np.ndarray, params: dict[str, np.ndarray]) -> np.ndarray:
+def normalize_values_meanstd(
+    values: np.ndarray, params: dict[str, np.ndarray]
+) -> np.ndarray:
     """Mean-std normalize (zero-std dims pass through unchanged)."""
     mean_vals = params["mean"]
     std_vals = params["std"]
@@ -447,9 +451,9 @@ def unnormalize_values_meanstd(
     std_vals = params["std"]
     unnormalized = np.zeros_like(normalized_values)
     mask = std_vals != 0
-    unnormalized[..., mask] = normalized_values[..., mask] * std_vals[
-        ..., mask
-    ] + mean_vals[..., mask]
+    unnormalized[..., mask] = (
+        normalized_values[..., mask] * std_vals[..., mask] + mean_vals[..., mask]
+    )
     unnormalized[..., ~mask] = normalized_values[..., ~mask]
     return unnormalized
 

--- a/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/processor_gr00t.py
+++ b/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/processor_gr00t.py
@@ -225,9 +225,8 @@ def _has_local_tokenizer_files(path: Path) -> bool:
     """Whether ``path`` can satisfy ``AutoTokenizer.from_pretrained(path)``."""
     if not path.is_dir() or not (path / "tokenizer_config.json").exists():
         return False
-    return (
-        (path / "tokenizer.json").exists()
-        or ((path / "vocab.json").exists() and (path / "merges.txt").exists())
+    return (path / "tokenizer.json").exists() or (
+        (path / "vocab.json").exists() and (path / "merges.txt").exists()
     )
 
 
@@ -388,7 +387,10 @@ class GR00TProcessor:
         state_data = {key: observation.state[key] for key in state_keys}
         if self.exclude_state:
             normalized_states = torch.cat(
-                [torch.from_numpy(np.zeros_like(state_data[key])) for key in state_keys],
+                [
+                    torch.from_numpy(np.zeros_like(state_data[key]))
+                    for key in state_keys
+                ],
                 dim=-1,
             )
         else:
@@ -406,7 +408,10 @@ class GR00TProcessor:
             self.max_state_dim - normalized_states.shape[-1],
         )
         normalized_states = torch.cat(
-            [normalized_states, torch.zeros(padding_shape, dtype=normalized_states.dtype)],
+            [
+                normalized_states,
+                torch.zeros(padding_shape, dtype=normalized_states.dtype),
+            ],
             dim=-1,
         )
         batch = normalized_states.shape[0]
@@ -416,9 +421,7 @@ class GR00TProcessor:
                 f"Action horizon {action_horizon} exceeds "
                 f"max_action_horizon {self.max_action_horizon}."
             )
-        action_mask = torch.zeros(
-            (batch, self.max_action_horizon), dtype=torch.float32
-        )
+        action_mask = torch.zeros((batch, self.max_action_horizon), dtype=torch.float32)
         action_mask[:, :action_horizon] = 1.0
         embodiment_id = torch.full(
             (batch,),
@@ -468,7 +471,9 @@ class GR00TProcessor:
 
     # -------------------------------------------- #
 
-    def preprocess(self, observation: GR00TObservation | dict[str, Any]) -> GR00TProcessedInputs:
+    def preprocess(
+        self, observation: GR00TObservation | dict[str, Any]
+    ) -> GR00TProcessedInputs:
         """Alias for :meth:`process_observation` (accepts a raw dict too)."""
         return self.process_observation(ensure_numpy_observation(observation))
 
@@ -757,7 +762,9 @@ class GR00TProcessor:
 
     def _native_tokenizer(self) -> Any:
         if self._tokenizer is None:
-            tokenizer = get_tokenizer(self.model_name, **self.transformers_loading_kwargs)
+            tokenizer = get_tokenizer(
+                self.model_name, **self.transformers_loading_kwargs
+            )
             tokenizer.padding_side = "left"
             self._tokenizer = tokenizer
         return self._tokenizer

--- a/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/processor_gr00t.py
+++ b/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/processor_gr00t.py
@@ -1,0 +1,802 @@
+"""GR00T-N1.7 processor — checkpoint-agnostic state/action/vision preprocessing.
+
+Relocated out of the phyai engine (``phyai.models.gr00t_n17``) so the engine owns
+only modeling/runner/scheduler and consumes already-prepared tensors. The package
+is a workspace leaf: it depends only on numpy / torch / PIL and an injected (or
+``phyai_utils_tools``-loaded) tokenizer — **no ``phyai`` import**.
+
+GR00T ships its own structured checkpoint contract:
+
+* ``processor_config.json`` — per-embodiment modality keys, horizons, action
+  interpretation, and processor kwargs.
+* ``statistics.json`` — min/max, percentile, mean, std for state/action norm.
+* ``embodiment_id.json`` — checkpoint embodiment tag -> action-head slot.
+
+Image/token processing follows the official deterministic eval transform, then a
+native Qwen3-VL preprocessor (patchify + chat-template image-token expansion);
+the pure transforms / normalization math live in :mod:`.ops_gr00t`.
+"""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+import torch
+
+from phyai_utils_tools.models.gr00t.ops_gr00t import (
+    DEFAULT_EMBODIMENT_ID_MAPPING,
+    apply_sin_cos_encoding,
+    enum_value,
+    eval_transform_image,
+    load_json,
+    load_preprocessor_config,
+    normalize_values_meanstd,
+    normalize_values_minmax,
+    qwen3vl_process_image,
+    relative_eef_to_absolute,
+    relative_non_eef_to_absolute,
+    resolve_embodiment_tag,
+    tuple2,
+    unnormalize_values_meanstd,
+    unnormalize_values_minmax,
+)
+from phyai_utils_tools.tokenizer import get_tokenizer
+
+
+@dataclass(frozen=True)
+class GR00TActionConfig:
+    """Per-action-group interpretation metadata."""
+
+    rep: str
+    type: str
+    format: str
+    state_key: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GR00TActionConfig":
+        return cls(
+            rep=enum_value(data["rep"]),
+            type=enum_value(data["type"]),
+            format=enum_value(data["format"]),
+            state_key=data.get("state_key"),
+        )
+
+
+@dataclass(frozen=True)
+class GR00TModalityConfig:
+    """Checkpoint modality config for video/state/action/language."""
+
+    delta_indices: list[int]
+    modality_keys: list[str]
+    action_configs: list[GR00TActionConfig] | None = None
+    sin_cos_embedding_keys: list[str] | None = None
+    mean_std_embedding_keys: list[str] | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GR00TModalityConfig":
+        raw_action_configs = data.get("action_configs")
+        action_configs = None
+        if raw_action_configs is not None:
+            action_configs = [
+                GR00TActionConfig.from_dict(v) for v in raw_action_configs
+            ]
+        return cls(
+            delta_indices=[int(v) for v in data["delta_indices"]],
+            modality_keys=[str(v) for v in data["modality_keys"]],
+            action_configs=action_configs,
+            sin_cos_embedding_keys=data.get("sin_cos_embedding_keys"),
+            mean_std_embedding_keys=data.get("mean_std_embedding_keys"),
+        )
+
+    def __post_init__(self) -> None:
+        if not self.delta_indices:
+            raise ValueError("delta_indices must be non-empty.")
+        if not self.modality_keys:
+            raise ValueError("modality_keys must be non-empty.")
+        if self.action_configs is not None and len(self.action_configs) != len(
+            self.modality_keys
+        ):
+            raise ValueError(
+                "action_configs length must match modality_keys length: "
+                f"{len(self.action_configs)} != {len(self.modality_keys)}."
+            )
+
+
+@dataclass(frozen=True)
+class GR00TObservation:
+    """Batched raw observation in the public GR00T policy shape.
+
+    * ``video[view]``: ``np.uint8`` array shaped ``(B, T, H, W, 3)``.
+    * ``state[name]``: ``np.float32`` array shaped ``(B, T, D)``.
+    * ``language[name]``: nested ``list[list[str]]`` shaped ``(B, T)``.
+    """
+
+    video: dict[str, np.ndarray]
+    state: dict[str, np.ndarray]
+    language: dict[str, list[list[str]]]
+
+
+@dataclass(frozen=True)
+class GR00TProcessedInputs:
+    """Tensor inputs consumed by the native GR00T-N1.7 scheduler."""
+
+    tensors: dict[str, torch.Tensor]
+    raw_state: dict[str, np.ndarray] | None = None
+
+
+def parse_modality_configs(
+    modality_configs: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, GR00TModalityConfig]]:
+    """Parse a raw modality-config mapping into :class:`GR00TModalityConfig`."""
+    parsed: dict[str, dict[str, GR00TModalityConfig]] = {}
+    for embodiment_tag, cfg in modality_configs.items():
+        parsed[embodiment_tag] = {}
+        for modality, value in cfg.items():
+            parsed[embodiment_tag][modality] = (
+                value
+                if isinstance(value, GR00TModalityConfig)
+                else GR00TModalityConfig.from_dict(value)
+            )
+    return parsed
+
+
+def ensure_numpy_observation(value: Any) -> GR00TObservation:
+    """Validate / coerce the top-level raw observation shape."""
+    if isinstance(value, GR00TObservation):
+        return value
+    if not isinstance(value, dict):
+        raise TypeError("GR00T observation must be a GR00TObservation or dict.")
+    try:
+        return GR00TObservation(
+            video=value["video"],
+            state=value["state"],
+            language=value["language"],
+        )
+    except KeyError as e:
+        raise ValueError("observation requires video, state, and language keys.") from e
+
+
+def _build_norm_params(
+    statistics: dict[str, Any],
+    modality_configs: dict[str, dict[str, GR00TModalityConfig]],
+    *,
+    use_percentiles: bool,
+    use_relative_action: bool,
+) -> dict[str, dict[str, dict[str, dict[str, np.ndarray]]]]:
+    """Build per-embodiment min/max/mean/std (+ relative) normalization params."""
+    norm_params: dict[str, dict[str, dict[str, dict[str, np.ndarray]]]] = {}
+    for embodiment_tag, stats_for_tag in statistics.items():
+        norm_params[embodiment_tag] = {}
+        for modality in ("state", "action"):
+            if modality not in stats_for_tag:
+                continue
+            norm_params[embodiment_tag][modality] = {}
+            for key, stats in stats_for_tag[modality].items():
+                min_vals = np.asarray(
+                    stats["q01"] if use_percentiles else stats["min"],
+                    dtype=np.float32,
+                )
+                max_vals = np.asarray(
+                    stats["q99"] if use_percentiles else stats["max"],
+                    dtype=np.float32,
+                )
+                mean_vals = np.asarray(stats["mean"], dtype=np.float32)
+                std_vals = np.asarray(stats["std"], dtype=np.float32)
+                norm_params[embodiment_tag][modality][key] = {
+                    "min": min_vals,
+                    "max": max_vals,
+                    "mean": mean_vals,
+                    "std": std_vals,
+                    "dim": np.asarray(min_vals.shape[0], dtype=np.int64),
+                }
+        if not use_relative_action:
+            continue
+        tag_cfg = modality_configs.get(embodiment_tag)
+        if tag_cfg is None or "action" not in tag_cfg:
+            continue
+        action_cfg = tag_cfg["action"]
+        if action_cfg.action_configs is None:
+            continue
+        for key, config in zip(action_cfg.modality_keys, action_cfg.action_configs):
+            if config.rep != "relative":
+                continue
+            if "relative_action" not in stats_for_tag:
+                raise ValueError(
+                    f"Relative action statistics required for {embodiment_tag!r}."
+                )
+            action_dim = norm_params[embodiment_tag]["action"][key]["dim"]
+            relative = stats_for_tag["relative_action"][key]
+            norm_params[embodiment_tag]["action"][key] = {
+                k: np.asarray(v, dtype=np.float32)
+                for k, v in relative.items()
+                if k in ("min", "max", "mean", "std", "q01", "q99")
+            }
+            norm_params[embodiment_tag]["action"][key]["dim"] = action_dim
+    return norm_params
+
+
+def _has_local_tokenizer_files(path: Path) -> bool:
+    """Whether ``path`` can satisfy ``AutoTokenizer.from_pretrained(path)``."""
+    if not path.is_dir() or not (path / "tokenizer_config.json").exists():
+        return False
+    return (
+        (path / "tokenizer.json").exists()
+        or ((path / "vocab.json").exists() and (path / "merges.txt").exists())
+    )
+
+
+class GR00TProcessor:
+    """Checkpoint-agnostic GR00T-N1.7 state/action/vision processor.
+
+    Mirrors Isaac-GR00T's ``Gr00tN1d7Processor`` contract but with a native
+    (no ``transformers`` processor) Qwen3-VL image/token path. Construct
+    programmatically, or via :meth:`from_pretrained` against a GR00T checkpoint
+    directory. The primary API is :meth:`process_observation` (raw obs -> tensors)
+    and :meth:`decode_action` (normalized action -> physical action).
+    """
+
+    def __init__(
+        self,
+        *,
+        embodiment_tag: str,
+        modality_configs: dict[str, dict[str, GR00TModalityConfig]] | None = None,
+        statistics: dict[str, Any] | None = None,
+        embodiment_id_mapping: dict[str, int] | None = None,
+        max_state_dim: int = 132,
+        max_action_dim: int = 132,
+        max_action_horizon: int = 40,
+        use_percentiles: bool = True,
+        clip_outliers: bool = True,
+        apply_sincos_state_encoding: bool = False,
+        use_relative_action: bool = False,
+        use_mean_std: bool = False,
+        exclude_state: bool = False,
+        formalize_language: bool = True,
+        model_name: str = "nvidia/Cosmos-Reason2-2B",
+        model_type: str = "qwen",
+        image_crop_size: list[int] | tuple[int, int] | None = (230, 230),
+        image_target_size: list[int] | tuple[int, int] | None = (256, 256),
+        shortest_image_edge: int | None = 256,
+        crop_fraction: float | None = 0.95,
+        use_albumentations: bool = True,
+        transformers_loading_kwargs: dict[str, Any] | None = None,
+        tokenizer: Any | None = None,
+        vlm_processor: Any | None = None,
+    ) -> None:
+        self.embodiment_tag = resolve_embodiment_tag(embodiment_tag)
+        self.modality_configs = modality_configs or {}
+        self.statistics = deepcopy(statistics or {})
+        self.embodiment_id_mapping = dict(DEFAULT_EMBODIMENT_ID_MAPPING)
+        if embodiment_id_mapping is not None:
+            self.embodiment_id_mapping.update(
+                {str(k): int(v) for k, v in embodiment_id_mapping.items()}
+            )
+        self.max_state_dim = int(max_state_dim)
+        self.max_action_dim = int(max_action_dim)
+        self.max_action_horizon = int(max_action_horizon)
+        self.use_percentiles = bool(use_percentiles)
+        self.use_mean_std = bool(use_mean_std)
+        self.clip_outliers = bool(clip_outliers)
+        self.apply_sincos_state_encoding = bool(apply_sincos_state_encoding)
+        self.use_relative_action = bool(use_relative_action)
+        self.exclude_state = bool(exclude_state)
+        self.formalize_language = bool(formalize_language)
+        self.model_name = model_name
+        self.model_type = model_type
+        self.image_crop_size = tuple2(image_crop_size)
+        self.image_target_size = tuple2(image_target_size)
+        self.shortest_image_edge = shortest_image_edge
+        self.crop_fraction = crop_fraction
+        self.use_albumentations = bool(use_albumentations)
+        self.transformers_loading_kwargs = dict(transformers_loading_kwargs or {})
+        self._tokenizer = tokenizer
+        self.vlm_processor = vlm_processor
+        if self.vlm_processor is not None and hasattr(self.vlm_processor, "tokenizer"):
+            self.vlm_processor.tokenizer.padding_side = "left"
+        self._image_params_cache: dict[str, Any] | None = None
+        self.norm_params = _build_norm_params(
+            self.statistics,
+            self.modality_configs,
+            use_percentiles=self.use_percentiles,
+            use_relative_action=self.use_relative_action,
+        )
+        self._validate_embodiment()
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | Path,
+        *,
+        embodiment_tag: str,
+        **overrides: Any,
+    ) -> "GR00TProcessor":
+        root = Path(pretrained_model_name_or_path)
+        processor_root = (
+            root / "processor"
+            if (root / "processor").is_dir()
+            and not (root / "processor_config.json").exists()
+            else root
+        )
+        processor_config = load_json(processor_root / "processor_config.json")
+        statistics = load_json(processor_root / "statistics.json")
+        embodiment_id_path = processor_root / "embodiment_id.json"
+        embodiment_id_mapping = (
+            load_json(embodiment_id_path) if embodiment_id_path.exists() else None
+        )
+
+        kwargs = dict(processor_config["processor_kwargs"])
+        local_model_dir = (
+            processor_root if _has_local_tokenizer_files(processor_root) else root
+        )
+        if not _has_local_tokenizer_files(local_model_dir):
+            local_model_dir = None
+        kwargs.setdefault(
+            "model_name",
+            str(local_model_dir)
+            if local_model_dir is not None
+            else "nvidia/Cosmos-Reason2-2B",
+        )
+        kwargs.setdefault("model_type", "qwen")
+        kwargs.setdefault("clip_outliers", True)
+        kwargs["statistics"] = statistics
+        kwargs["embodiment_id_mapping"] = embodiment_id_mapping
+        kwargs.update({k: v for k, v in overrides.items() if v is not None})
+        modality_configs = parse_modality_configs(kwargs.pop("modality_configs"))
+        keep = {
+            "max_state_dim",
+            "max_action_dim",
+            "max_action_horizon",
+            "use_percentiles",
+            "clip_outliers",
+            "apply_sincos_state_encoding",
+            "use_relative_action",
+            "use_mean_std",
+            "exclude_state",
+            "formalize_language",
+            "model_name",
+            "model_type",
+            "image_crop_size",
+            "image_target_size",
+            "shortest_image_edge",
+            "crop_fraction",
+            "use_albumentations",
+            "transformers_loading_kwargs",
+            "tokenizer",
+            "vlm_processor",
+        }
+        init_kwargs = {k: kwargs[k] for k in keep if k in kwargs}
+        return cls(
+            embodiment_tag=embodiment_tag,
+            modality_configs=modality_configs,
+            statistics=statistics,
+            embodiment_id_mapping=embodiment_id_mapping,
+            **init_kwargs,
+        )
+
+    def process_observation(
+        self, observation: GR00TObservation
+    ) -> GR00TProcessedInputs:
+        cfg = self.modality_config
+        self._validate_observation(observation)
+        state_keys = cfg["state"].modality_keys
+        state_data = {key: observation.state[key] for key in state_keys}
+        if self.exclude_state:
+            normalized_states = torch.cat(
+                [torch.from_numpy(np.zeros_like(state_data[key])) for key in state_keys],
+                dim=-1,
+            )
+        else:
+            norm_state = self.apply_state(state_data)
+            normalized_states = torch.cat(
+                [torch.from_numpy(norm_state[key]) for key in state_keys], dim=-1
+            )
+        if normalized_states.shape[-1] > self.max_state_dim:
+            raise ValueError(
+                f"State dimension {normalized_states.shape[-1]} exceeds "
+                f"max_state_dim {self.max_state_dim}."
+            )
+        padding_shape = (
+            *normalized_states.shape[:-1],
+            self.max_state_dim - normalized_states.shape[-1],
+        )
+        normalized_states = torch.cat(
+            [normalized_states, torch.zeros(padding_shape, dtype=normalized_states.dtype)],
+            dim=-1,
+        )
+        batch = normalized_states.shape[0]
+        action_horizon = len(cfg["action"].delta_indices)
+        if action_horizon > self.max_action_horizon:
+            raise ValueError(
+                f"Action horizon {action_horizon} exceeds "
+                f"max_action_horizon {self.max_action_horizon}."
+            )
+        action_mask = torch.zeros(
+            (batch, self.max_action_horizon), dtype=torch.float32
+        )
+        action_mask[:, :action_horizon] = 1.0
+        embodiment_id = torch.full(
+            (batch,),
+            self.embodiment_id,
+            dtype=torch.int32,
+        )
+        vlm_tensors = self._process_vlm(observation)
+        tensors = {
+            "state": normalized_states.to(torch.get_default_dtype()),
+            "embodiment_id": embodiment_id,
+            "action_mask": action_mask,
+        }
+        tensors.update(vlm_tensors)
+        return GR00TProcessedInputs(
+            tensors=tensors,
+            raw_state=deepcopy(state_data),
+        )
+
+    def decode_action(
+        self,
+        normalized_action: torch.Tensor | np.ndarray,
+        *,
+        raw_state: dict[str, np.ndarray] | None = None,
+    ) -> dict[str, np.ndarray]:
+        if isinstance(normalized_action, torch.Tensor):
+            action = normalized_action.detach().float().cpu().numpy()
+        else:
+            action = np.asarray(normalized_action)
+        cfg = self.modality_config["action"]
+        action_horizon = len(cfg.delta_indices)
+        out_dict: dict[str, np.ndarray] = {}
+        start_idx = 0
+        for key in cfg.modality_keys:
+            dim = int(self.norm_params[self.embodiment_tag]["action"][key]["dim"])
+            out_dict[key] = action[..., :action_horizon, start_idx : start_idx + dim]
+            start_idx += dim
+        if action.shape[-1] < start_idx:
+            raise ValueError(
+                f"normalized_action last dimension {action.shape[-1]} is smaller "
+                f"than required action dim {start_idx}."
+            )
+        state = None
+        if raw_state is not None:
+            state = {k.replace("state.", ""): v for k, v in raw_state.items()}
+        decoded = self.unapply_action(out_dict, raw_state=state)
+        return {f"action.{key}": value for key, value in decoded.items()}
+
+    # -------------------------------------------- #
+
+    def preprocess(self, observation: GR00TObservation | dict[str, Any]) -> GR00TProcessedInputs:
+        """Alias for :meth:`process_observation` (accepts a raw dict too)."""
+        return self.process_observation(ensure_numpy_observation(observation))
+
+    def postprocess(
+        self,
+        normalized_action: torch.Tensor | np.ndarray,
+        *,
+        raw_state: dict[str, np.ndarray] | None = None,
+    ) -> dict[str, np.ndarray]:
+        """Alias for :meth:`decode_action`."""
+        return self.decode_action(normalized_action, raw_state=raw_state)
+
+    @property
+    def modality_config(self) -> dict[str, GR00TModalityConfig]:
+        return self.modality_configs[self.embodiment_tag]
+
+    @property
+    def embodiment_id(self) -> int:
+        if self.embodiment_tag not in self.embodiment_id_mapping:
+            raise ValueError(
+                f"Embodiment tag {self.embodiment_tag!r} has no embodiment id. "
+                f"Available tags include: {sorted(self.embodiment_id_mapping)[:8]}"
+            )
+        return self.embodiment_id_mapping[self.embodiment_tag]
+
+    def apply_state(self, state: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        normalized_values: dict[str, np.ndarray] = {}
+        state_cfg = self.modality_config["state"]
+        sin_cos_keys = (
+            set(state_cfg.sin_cos_embedding_keys or [])
+            if self.apply_sincos_state_encoding
+            else set()
+        )
+        mean_std_keys = set(state_cfg.mean_std_embedding_keys or [])
+        for key in state_cfg.modality_keys:
+            if key not in state:
+                raise KeyError(
+                    f"State key {key!r} missing for embodiment {self.embodiment_tag!r}."
+                )
+            values = state[key]
+            if key in sin_cos_keys:
+                normalized = apply_sin_cos_encoding(values)
+            elif key in mean_std_keys:
+                normalized = normalize_values_meanstd(
+                    values, self.norm_params[self.embodiment_tag]["state"][key]
+                )
+            else:
+                normalized = normalize_values_minmax(
+                    values, self.norm_params[self.embodiment_tag]["state"][key]
+                )
+                if self.clip_outliers:
+                    normalized = np.clip(normalized, -1.0, 1.0)
+            normalized_values[key] = normalized.astype(np.float32, copy=False)
+        return normalized_values
+
+    def unapply_action(
+        self,
+        action: dict[str, np.ndarray],
+        *,
+        raw_state: dict[str, np.ndarray] | None = None,
+    ) -> dict[str, np.ndarray]:
+        action_cfg = self.modality_config["action"]
+        mean_std_keys = set(action_cfg.mean_std_embedding_keys or [])
+        unnormalized: dict[str, np.ndarray] = {}
+        for key in action_cfg.modality_keys:
+            if key not in action:
+                raise KeyError(
+                    f"Action key {key!r} missing for embodiment {self.embodiment_tag!r}."
+                )
+            params = self.norm_params[self.embodiment_tag]["action"][key]
+            if key in mean_std_keys:
+                value = unnormalize_values_meanstd(action[key], params)
+            else:
+                value = unnormalize_values_minmax(action[key], params)
+            unnormalized[key] = value.astype(np.float32, copy=False)
+
+        if action_cfg.action_configs is None:
+            return unnormalized
+        for key, config in zip(action_cfg.modality_keys, action_cfg.action_configs):
+            if config.rep != "relative" or not self.use_relative_action:
+                continue
+            if raw_state is None:
+                raise ValueError(
+                    f"raw_state is required for relative action key {key!r}."
+                )
+            state_key = config.state_key or key
+            if state_key not in raw_state:
+                raise KeyError(
+                    f"Reference state key {state_key!r} missing for relative action "
+                    f"key {key!r}."
+                )
+            if config.type == "non_eef":
+                unnormalized[key] = relative_non_eef_to_absolute(
+                    unnormalized[key], raw_state[state_key]
+                )
+            elif config.type == "eef":
+                unnormalized[key] = relative_eef_to_absolute(
+                    unnormalized[key],
+                    raw_state[state_key],
+                    action_format=config.format,
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported relative action type {config.type!r} for key {key!r}."
+                )
+        return unnormalized
+
+    def _validate_embodiment(self) -> None:
+        if self.modality_configs and self.embodiment_tag not in self.modality_configs:
+            raise ValueError(
+                f"Embodiment tag {self.embodiment_tag!r} is not present in "
+                "processor modality_configs."
+            )
+        if self.statistics and self.embodiment_tag not in self.statistics:
+            raise ValueError(
+                f"Embodiment tag {self.embodiment_tag!r} is not present in statistics."
+            )
+
+    def _validate_observation(self, observation: GR00TObservation) -> None:
+        cfg = self.modality_config
+        for key in cfg["state"].modality_keys:
+            if key not in observation.state:
+                raise ValueError(f"observation.state requires key {key!r}.")
+            arr = observation.state[key]
+            if not isinstance(arr, np.ndarray) or arr.dtype != np.float32:
+                raise TypeError(f"state {key!r} must be np.float32 ndarray.")
+            if arr.ndim != 3:
+                raise ValueError(f"state {key!r} must have shape (B,T,D).")
+            if arr.shape[1] != len(cfg["state"].delta_indices):
+                raise ValueError(
+                    f"state {key!r} horizon mismatch: got {arr.shape[1]}, "
+                    f"expected {len(cfg['state'].delta_indices)}."
+                )
+        for key in cfg["language"].modality_keys:
+            if key not in observation.language:
+                raise ValueError(f"observation.language requires key {key!r}.")
+        for key in cfg["video"].modality_keys:
+            if key not in observation.video:
+                raise ValueError(f"observation.video requires key {key!r}.")
+            arr = observation.video[key]
+            if not isinstance(arr, np.ndarray) or arr.dtype != np.uint8:
+                raise TypeError(f"video {key!r} must be np.uint8 ndarray.")
+            if arr.ndim != 5 or arr.shape[-1] != 3:
+                raise ValueError(f"video {key!r} must have shape (B,T,H,W,3).")
+            if arr.shape[1] != len(cfg["video"].delta_indices):
+                raise ValueError(
+                    f"video {key!r} horizon mismatch: got {arr.shape[1]}, "
+                    f"expected {len(cfg['video'].delta_indices)}."
+                )
+
+    def _language(self, observation: GR00TObservation) -> list[str]:
+        language_key = self.modality_config["language"].modality_keys[0]
+        language = []
+        for item in observation.language[language_key]:
+            text = item[0]
+            if self.formalize_language:
+                text = re.sub(r"[^\w\s]", "", text.lower())
+            language.append(text)
+        return language
+
+    def _process_vlm(self, observation: GR00TObservation) -> dict[str, torch.Tensor]:
+        cfg = self.modality_config
+        image_keys = cfg["video"].modality_keys
+        images = [torch.from_numpy(observation.video[key]) for key in image_keys]
+        stacked = torch.stack(images, dim=2)
+        if stacked.ndim != 6:
+            raise ValueError("stacked video must have shape (B,T,V,H,W,C).")
+        batch, time, views, height, width, channels = stacked.shape
+        images_flat = stacked.reshape(batch, time * views, height, width, channels)
+        transformed_images = []
+        for b in range(batch):
+            transformed_frames = []
+            for frame in images_flat[b]:
+                transformed_frames.append(
+                    eval_transform_image(
+                        frame.numpy(),
+                        shortest_image_edge=self.shortest_image_edge,
+                        image_target_size=self.image_target_size,
+                        image_crop_size=self.image_crop_size,
+                        crop_fraction=self.crop_fraction,
+                    )
+                )
+            transformed_images.append(np.stack(transformed_frames, axis=0))
+
+        languages = self._language(observation)
+        if self.vlm_processor is not None:
+            return self._process_vlm_injected(transformed_images, languages)
+        return self._process_vlm_native(transformed_images, languages)
+
+    def _process_vlm_injected(
+        self, transformed_images: list[np.ndarray], languages: list[str]
+    ) -> dict[str, torch.Tensor]:
+        """Path used by tests that inject a processor-like ``vlm_processor``."""
+        processor = self.vlm_processor
+        texts: list[str] = []
+        all_images: list[Image.Image] = []
+        for images_for_item, language in zip(transformed_images, languages):
+            pil_images = [
+                Image.fromarray(np.transpose(v, (1, 2, 0))) for v in images_for_item
+            ]
+            conversation = [
+                {
+                    "role": "user",
+                    "content": [
+                        *[{"type": "image", "image": img} for img in pil_images],
+                        {"type": "text", "text": language},
+                    ],
+                }
+            ]
+            text = processor.apply_chat_template(
+                conversation, tokenize=False, add_generation_prompt=False
+            )
+            texts.append(text)
+            all_images.extend(pil_images)
+        tokenized = processor(
+            text=texts,
+            images=all_images,
+            return_tensors="pt",
+            padding=True,
+        )
+        return {k: v for k, v in tokenized.items() if isinstance(v, torch.Tensor)}
+
+    def _process_vlm_native(
+        self, transformed_images: list[np.ndarray], languages: list[str]
+    ) -> dict[str, torch.Tensor]:
+        """Native Qwen3-VL preprocessing — no ``transformers`` processor.
+
+        Replicates ``Qwen3VLProcessor.__call__``: the Qwen2-VL image processor
+        (``smart_resize`` -> rescale/normalize -> patchify -> ``pixel_values`` +
+        ``image_grid_thw``), the tokenizer's own chat template, and the per-image
+        ``<|image_pad|>`` expansion by ``grid_thw.prod() // merge_size**2``.
+        """
+        tokenizer = self._native_tokenizer()
+        params = self._image_params()
+        merge_length = int(params["merge_size"]) ** 2
+        image_token = "<|image_pad|>"
+
+        pixel_chunks: list[torch.Tensor] = []
+        grid_list: list[tuple[int, int, int]] = []
+        texts: list[str] = []
+        for images_for_item, language in zip(transformed_images, languages):
+            for frame in images_for_item:
+                pixel_values, grid_thw = qwen3vl_process_image(frame, params)
+                pixel_chunks.append(pixel_values)
+                grid_list.append(grid_thw)
+            conversation = [
+                {
+                    "role": "user",
+                    "content": [
+                        *[{"type": "image"} for _ in images_for_item],
+                        {"type": "text", "text": language},
+                    ],
+                }
+            ]
+            texts.append(
+                tokenizer.apply_chat_template(
+                    conversation, tokenize=False, add_generation_prompt=False
+                )
+            )
+
+        # Expand each placeholder image token to one token per merged patch,
+        # consuming grids in image order (mirrors Qwen3VLProcessor.__call__).
+        grid_index = 0
+        expanded: list[str] = []
+        for text in texts:
+            while image_token in text:
+                num = int(np.prod(grid_list[grid_index])) // merge_length
+                text = text.replace(image_token, "<|placeholder|>" * num, 1)
+                grid_index += 1
+            expanded.append(text.replace("<|placeholder|>", image_token))
+
+        tokenized = tokenizer(expanded, return_tensors="pt", padding=True)
+        outputs: dict[str, torch.Tensor] = {
+            k: v for k, v in tokenized.items() if isinstance(v, torch.Tensor)
+        }
+        outputs["pixel_values"] = torch.cat(pixel_chunks, dim=0)
+        outputs["image_grid_thw"] = torch.tensor(grid_list, dtype=torch.long)
+        # mm_token_type_ids: 1 at image tokens, 0 elsewhere.
+        input_ids = outputs.get("input_ids")
+        if input_ids is not None:
+            image_id = tokenizer.convert_tokens_to_ids(image_token)
+            mm_token_type_ids = torch.zeros_like(input_ids)
+            mm_token_type_ids[input_ids == image_id] = 1
+            outputs["mm_token_type_ids"] = mm_token_type_ids
+        return outputs
+
+    def _native_tokenizer(self) -> Any:
+        if self._tokenizer is None:
+            tokenizer = get_tokenizer(self.model_name, **self.transformers_loading_kwargs)
+            tokenizer.padding_side = "left"
+            self._tokenizer = tokenizer
+        return self._tokenizer
+
+    def _image_params(self) -> dict[str, Any]:
+        if self._image_params_cache is not None:
+            return self._image_params_cache
+        config = load_preprocessor_config(
+            self.model_name,
+            local_files_only=bool(
+                self.transformers_loading_kwargs.get("local_files_only", False)
+            ),
+        )
+        size = config.get("size", {}) if config else {}
+        params = {
+            "patch_size": int(config.get("patch_size", 16)) if config else 16,
+            "temporal_patch_size": int(config.get("temporal_patch_size", 2))
+            if config
+            else 2,
+            "merge_size": int(config.get("merge_size", 2)) if config else 2,
+            "image_mean": list(config.get("image_mean", [0.5, 0.5, 0.5]))
+            if config
+            else [0.5, 0.5, 0.5],
+            "image_std": list(config.get("image_std", [0.5, 0.5, 0.5]))
+            if config
+            else [0.5, 0.5, 0.5],
+            "min_pixels": int(size.get("shortest_edge", 4 * 28 * 28)),
+            "max_pixels": int(size.get("longest_edge", 16777216)),
+        }
+        self._image_params_cache = params
+        return params
+
+
+__all__ = [
+    "GR00TActionConfig",
+    "GR00TModalityConfig",
+    "GR00TObservation",
+    "GR00TProcessedInputs",
+    "GR00TProcessor",
+    "ensure_numpy_observation",
+    "parse_modality_configs",
+]

--- a/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/processor_gr00t.py
+++ b/phyai-utils-tools/src/phyai_utils_tools/models/gr00t/processor_gr00t.py
@@ -295,6 +295,8 @@ class GR00TProcessor:
         self.use_albumentations = bool(use_albumentations)
         self.transformers_loading_kwargs = dict(transformers_loading_kwargs or {})
         self._tokenizer = tokenizer
+        if self._tokenizer is not None:
+            self._tokenizer.padding_side = "left"
         self.vlm_processor = vlm_processor
         if self.vlm_processor is not None and hasattr(self.vlm_processor, "tokenizer"):
             self.vlm_processor.tokenizer.padding_side = "left"
@@ -345,7 +347,7 @@ class GR00TProcessor:
         kwargs.setdefault("clip_outliers", True)
         kwargs["statistics"] = statistics
         kwargs["embodiment_id_mapping"] = embodiment_id_mapping
-        kwargs.update({k: v for k, v in overrides.items() if v is not None})
+        kwargs.update(overrides)
         modality_configs = parse_modality_configs(kwargs.pop("modality_configs"))
         keep = {
             "max_state_dim",
@@ -452,17 +454,21 @@ class GR00TProcessor:
             action = np.asarray(normalized_action)
         cfg = self.modality_config["action"]
         action_horizon = len(cfg.delta_indices)
+        total_dim = sum(
+            int(self.norm_params[self.embodiment_tag]["action"][key]["dim"])
+            for key in cfg.modality_keys
+        )
+        if action.shape[-1] < total_dim:
+            raise ValueError(
+                f"normalized_action last dimension {action.shape[-1]} is smaller "
+                f"than required action dim {total_dim}."
+            )
         out_dict: dict[str, np.ndarray] = {}
         start_idx = 0
         for key in cfg.modality_keys:
             dim = int(self.norm_params[self.embodiment_tag]["action"][key]["dim"])
             out_dict[key] = action[..., :action_horizon, start_idx : start_idx + dim]
             start_idx += dim
-        if action.shape[-1] < start_idx:
-            raise ValueError(
-                f"normalized_action last dimension {action.shape[-1]} is smaller "
-                f"than required action dim {start_idx}."
-            )
         state = None
         if raw_state is not None:
             state = {k.replace("state.", ""): v for k, v in raw_state.items()}
@@ -516,7 +522,7 @@ class GR00TProcessor:
             values = state[key]
             if key in sin_cos_keys:
                 normalized = apply_sin_cos_encoding(values)
-            elif key in mean_std_keys:
+            elif self.use_mean_std or key in mean_std_keys:
                 normalized = normalize_values_meanstd(
                     values, self.norm_params[self.embodiment_tag]["state"][key]
                 )
@@ -544,7 +550,7 @@ class GR00TProcessor:
                     f"Action key {key!r} missing for embodiment {self.embodiment_tag!r}."
                 )
             params = self.norm_params[self.embodiment_tag]["action"][key]
-            if key in mean_std_keys:
+            if self.use_mean_std or key in mean_std_keys:
                 value = unnormalize_values_meanstd(action[key], params)
             else:
                 value = unnormalize_values_minmax(action[key], params)
@@ -740,6 +746,11 @@ class GR00TProcessor:
         expanded: list[str] = []
         for text in texts:
             while image_token in text:
+                if grid_index >= len(grid_list):
+                    raise ValueError(
+                        f"Found more {image_token!r} tokens in the formatted text "
+                        f"than processed images ({len(grid_list)})."
+                    )
                 num = int(np.prod(grid_list[grid_index])) // merge_length
                 text = text.replace(image_token, "<|placeholder|>" * num, 1)
                 grid_index += 1

--- a/phyai/pyproject.toml
+++ b/phyai/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
 
 [project.optional-dependencies]
 ext = ["phyai-ext"]
-fastokenizer = ["fastokens>=0.2.0"]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/phyai/pyproject.toml
+++ b/phyai/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ext = ["phyai-ext"]
+fastokenizer = ["fastokens>=0.2.0"]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/phyai/src/phyai/engine.py
+++ b/phyai/src/phyai/engine.py
@@ -210,19 +210,19 @@ class Engine:
         return tuple(cls._plugins.keys())
 
     def __init__(self, args: EngineArgs) -> None:
-        # 1. Resolve EngineConfig and seed the process singleton so every
-        #    model constructor downstream picks up the requested
-        #    device / dtype / backends without explicit plumbing.
-        #    ``from_env(base=args.config)`` makes the explicit config the
-        #    base and overlays any set ``PHYAI_*`` env var on top, so a
-        #    var like PHYAI_DEBUG_TENSOR_DUMP_DIR is honoured even when the
-        #    caller passed a config (env = run-time toggle). ``args.config``
-        #    is None -> the base falls back to ``auto()`` inside from_env.
-        #    When a tensor-dump directory ends up set, force eager *before*
-        #    installing the singleton: the dumper's forward hooks can't
-        #    fire inside a captured CUDA-graph replay, and the pi05
-        #    scheduler reads ``use_cuda_graph`` off this singleton at
-        #    setup time, so the flip has to land before any runner builds.
+        # Resolve EngineConfig and seed the process singleton so every
+        # model constructor downstream picks up the requested
+        # device / dtype / backends without explicit plumbing.
+        # ``from_env(base=args.config)`` makes the explicit config the
+        # base and overlays any set ``PHYAI_*`` env var on top, so a
+        # var like PHYAI_DEBUG_TENSOR_DUMP_DIR is honoured even when the
+        # caller passed a config (env = run-time toggle). ``args.config``
+        # is None -> the base falls back to ``auto()`` inside from_env.
+        # When a tensor-dump directory ends up set, force eager *before*
+        # installing the singleton: the dumper's forward hooks can't
+        # fire inside a captured CUDA-graph replay, and the pi05
+        # scheduler reads ``use_cuda_graph`` off this singleton at
+        # setup time, so the flip has to land before any runner builds.
         resolved = EngineConfig.from_env(base=args.config)
         self._dump_enabled = resolved.runtime.debug_tensor_dump_dir is not None
         if self._dump_enabled:
@@ -243,9 +243,9 @@ class Engine:
 
         device_type = torch.device(self.config.device.target).type
 
-        # 2. Per-concern bootstrap. Each ``init_*`` is independently
-        #    callable; this method is the only orchestrator. Saved
-        #    default dtype is restored in :meth:`close`.
+        # Per-concern bootstrap. Each ``init_*`` is independently
+        # callable; this method is the only orchestrator. Saved
+        # default dtype is restored in :meth:`close`.
         self._saved_default_dtype: torch.dtype = init_cuda(
             self.config.device.target, self.config.device.params_dtype
         )
@@ -255,27 +255,30 @@ class Engine:
             world_size=parallel.world_size, device_type=device_type
         )
 
-        # 3. phyai mesh + linear dispatcher. Both are process-level
-        #    singletons; building them here means model constructors
-        #    don't have to. The mesh is always 5-axis
-        #    (dp / ep / sp / cp / tp); axes the user didn't size stay at
-        #    ``1`` and short-circuit through the collective ops without
-        #    any process-group traffic, while existing model code that
-        #    addresses ``axis="tp"`` keeps working unchanged.
+        # phyai mesh + linear dispatcher. Both are process-level
+        # singletons; building them here means model constructors
+        # don't have to. The mesh is always 6-axis
+        # (dp / cfg / ep / sp / cp / tp); axes the user didn't size stay
+        # at ``1`` and short-circuit through the collective ops without
+        # any process-group traffic, while existing model code that
+        # addresses ``axis="tp"`` keeps working unchanged. ``cfg`` sits
+        # just outside ``tp`` so each CFG-parallel group is a contiguous
+        # tensor-parallel block.
         P.init(
             layout=(
                 parallel.dp_size,
+                parallel.cfg_size,
                 parallel.ep_size,
                 parallel.sp_size,
                 parallel.cp_size,
                 parallel.tp_size,
             ),
-            mesh_dim_names=("dp", "ep", "sp", "cp", "tp"),
+            mesh_dim_names=("dp", "cfg", "ep", "sp", "cp", "tp"),
             device=device_type,
         )
         L.init()
 
-        # 4. Resolve the requested plugin and validate the args bundle.
+        # Resolve the requested plugin and validate the args bundle.
         entry_cls = self._plugins.get(args.plugin)
         if entry_cls is None:
             raise ValueError(
@@ -288,16 +291,16 @@ class Engine:
                 f"{type(args.plugin_args).__name__}."
             )
 
-        # 5. Instantiate the entry and run setup. The entry owns its
-        #    model / scheduler / runners from this point on.
+        # Instantiate the entry and run setup. The entry owns its
+        # model / scheduler / runners from this point on.
         self.args = args
         self.entry: Entry = entry_cls()
         self.entry.setup(args.plugin_args)
 
-        # 6. If tensor dumping is on, attach the dumper to the modules the
-        #    plugin exposes. Built after setup() so the model + weights are
-        #    fully constructed; the runners were already forced eager in
-        #    step 1, so the leaf forward hooks will actually fire.
+        # If tensor dumping is on, attach the dumper to the modules the
+        # plugin exposes. Built after setup() so the model + weights are
+        # fully constructed; the runners were already forced eager in
+        # step 1, so the leaf forward hooks will actually fire.
         if self._dump_enabled:
             self._dumper = self._build_dumper()
 
@@ -384,9 +387,14 @@ __all__ = [
 # this module's symbols must be defined first.                           #
 # ---------------------------------------------------------------------- #
 
+from phyai.models.pi0 import main_pi0 as _main_pi0  # noqa: E402, F401
 from phyai.models.pi05 import main_pi05 as _main_pi05  # noqa: E402, F401
 from phyai.models.gr00t_n17 import main_gr00t_n17 as _main_gr00t_n17  # noqa: E402, F401
 from phyai.models.cosmos3 import main_cosmos3 as _main_cosmos3  # noqa: E402, F401
 from phyai.models.cosmos3 import (  # noqa: E402, F401
     main_cosmos3_policy as _main_cosmos3_policy,
+)
+from phyai.models.cosmos3 import main_cosmos3_wn as _main_cosmos3_wn  # noqa: E402, F401
+from phyai.models.cosmos3 import (  # noqa: E402, F401
+    main_cosmos3_policy_wn as _main_cosmos3_policy_wn,
 )

--- a/phyai/src/phyai/engine.py
+++ b/phyai/src/phyai/engine.py
@@ -210,19 +210,19 @@ class Engine:
         return tuple(cls._plugins.keys())
 
     def __init__(self, args: EngineArgs) -> None:
-        # Resolve EngineConfig and seed the process singleton so every
-        # model constructor downstream picks up the requested
-        # device / dtype / backends without explicit plumbing.
-        # ``from_env(base=args.config)`` makes the explicit config the
-        # base and overlays any set ``PHYAI_*`` env var on top, so a
-        # var like PHYAI_DEBUG_TENSOR_DUMP_DIR is honoured even when the
-        # caller passed a config (env = run-time toggle). ``args.config``
-        # is None -> the base falls back to ``auto()`` inside from_env.
-        # When a tensor-dump directory ends up set, force eager *before*
-        # installing the singleton: the dumper's forward hooks can't
-        # fire inside a captured CUDA-graph replay, and the pi05
-        # scheduler reads ``use_cuda_graph`` off this singleton at
-        # setup time, so the flip has to land before any runner builds.
+        # 1. Resolve EngineConfig and seed the process singleton so every
+        #    model constructor downstream picks up the requested
+        #    device / dtype / backends without explicit plumbing.
+        #    ``from_env(base=args.config)`` makes the explicit config the
+        #    base and overlays any set ``PHYAI_*`` env var on top, so a
+        #    var like PHYAI_DEBUG_TENSOR_DUMP_DIR is honoured even when the
+        #    caller passed a config (env = run-time toggle). ``args.config``
+        #    is None -> the base falls back to ``auto()`` inside from_env.
+        #    When a tensor-dump directory ends up set, force eager *before*
+        #    installing the singleton: the dumper's forward hooks can't
+        #    fire inside a captured CUDA-graph replay, and the pi05
+        #    scheduler reads ``use_cuda_graph`` off this singleton at
+        #    setup time, so the flip has to land before any runner builds.
         resolved = EngineConfig.from_env(base=args.config)
         self._dump_enabled = resolved.runtime.debug_tensor_dump_dir is not None
         if self._dump_enabled:
@@ -243,9 +243,9 @@ class Engine:
 
         device_type = torch.device(self.config.device.target).type
 
-        # Per-concern bootstrap. Each ``init_*`` is independently
-        # callable; this method is the only orchestrator. Saved
-        # default dtype is restored in :meth:`close`.
+        # 2. Per-concern bootstrap. Each ``init_*`` is independently
+        #    callable; this method is the only orchestrator. Saved
+        #    default dtype is restored in :meth:`close`.
         self._saved_default_dtype: torch.dtype = init_cuda(
             self.config.device.target, self.config.device.params_dtype
         )
@@ -255,30 +255,27 @@ class Engine:
             world_size=parallel.world_size, device_type=device_type
         )
 
-        # phyai mesh + linear dispatcher. Both are process-level
-        # singletons; building them here means model constructors
-        # don't have to. The mesh is always 6-axis
-        # (dp / cfg / ep / sp / cp / tp); axes the user didn't size stay
-        # at ``1`` and short-circuit through the collective ops without
-        # any process-group traffic, while existing model code that
-        # addresses ``axis="tp"`` keeps working unchanged. ``cfg`` sits
-        # just outside ``tp`` so each CFG-parallel group is a contiguous
-        # tensor-parallel block.
+        # 3. phyai mesh + linear dispatcher. Both are process-level
+        #    singletons; building them here means model constructors
+        #    don't have to. The mesh is always 5-axis
+        #    (dp / ep / sp / cp / tp); axes the user didn't size stay at
+        #    ``1`` and short-circuit through the collective ops without
+        #    any process-group traffic, while existing model code that
+        #    addresses ``axis="tp"`` keeps working unchanged.
         P.init(
             layout=(
                 parallel.dp_size,
-                parallel.cfg_size,
                 parallel.ep_size,
                 parallel.sp_size,
                 parallel.cp_size,
                 parallel.tp_size,
             ),
-            mesh_dim_names=("dp", "cfg", "ep", "sp", "cp", "tp"),
+            mesh_dim_names=("dp", "ep", "sp", "cp", "tp"),
             device=device_type,
         )
         L.init()
 
-        # Resolve the requested plugin and validate the args bundle.
+        # 4. Resolve the requested plugin and validate the args bundle.
         entry_cls = self._plugins.get(args.plugin)
         if entry_cls is None:
             raise ValueError(
@@ -291,16 +288,16 @@ class Engine:
                 f"{type(args.plugin_args).__name__}."
             )
 
-        # Instantiate the entry and run setup. The entry owns its
-        # model / scheduler / runners from this point on.
+        # 5. Instantiate the entry and run setup. The entry owns its
+        #    model / scheduler / runners from this point on.
         self.args = args
         self.entry: Entry = entry_cls()
         self.entry.setup(args.plugin_args)
 
-        # If tensor dumping is on, attach the dumper to the modules the
-        # plugin exposes. Built after setup() so the model + weights are
-        # fully constructed; the runners were already forced eager in
-        # step 1, so the leaf forward hooks will actually fire.
+        # 6. If tensor dumping is on, attach the dumper to the modules the
+        #    plugin exposes. Built after setup() so the model + weights are
+        #    fully constructed; the runners were already forced eager in
+        #    step 1, so the leaf forward hooks will actually fire.
         if self._dump_enabled:
             self._dumper = self._build_dumper()
 
@@ -387,13 +384,9 @@ __all__ = [
 # this module's symbols must be defined first.                           #
 # ---------------------------------------------------------------------- #
 
-from phyai.models.pi0 import main_pi0 as _main_pi0  # noqa: E402, F401
 from phyai.models.pi05 import main_pi05 as _main_pi05  # noqa: E402, F401
+from phyai.models.gr00t_n17 import main_gr00t_n17 as _main_gr00t_n17  # noqa: E402, F401
 from phyai.models.cosmos3 import main_cosmos3 as _main_cosmos3  # noqa: E402, F401
 from phyai.models.cosmos3 import (  # noqa: E402, F401
     main_cosmos3_policy as _main_cosmos3_policy,
-)
-from phyai.models.cosmos3 import main_cosmos3_wn as _main_cosmos3_wn  # noqa: E402, F401
-from phyai.models.cosmos3 import (  # noqa: E402, F401
-    main_cosmos3_policy_wn as _main_cosmos3_policy_wn,
 )

--- a/phyai/src/phyai/models/gr00t_n17/__init__.py
+++ b/phyai/src/phyai/models/gr00t_n17/__init__.py
@@ -1,0 +1,50 @@
+"""phyai.models.gr00t_n17 — GR00T-N1.7 native inference support."""
+
+from __future__ import annotations
+
+from phyai.models.gr00t_n17.configuration_gr00t_n17 import (
+    GR00TN17ActionHeadConfig,
+    GR00TN17BackboneConfig,
+    GR00TN17Config,
+    GR00TN17DiTConfig,
+    GR00TN17ProcessorConfig,
+    GR00TN17VLSelfAttentionConfig,
+)
+from phyai.models.gr00t_n17.main_gr00t_n17 import (
+    GR00TN17Args,
+    GR00TN17Entry,
+    gr00t_n17_weight_remap,
+)
+from phyai.models.gr00t_n17.modeling_gr00t_n17 import (
+    GR00TN17ActionHead,
+    GR00TN17ActionInput,
+    GR00TN17Backbone,
+    GR00TN17BackboneOutput,
+    GR00TN17Model,
+    GR00TN17NativeImplementationError,
+)
+from phyai.models.gr00t_n17.scheduler_ws1_gr00t_n17 import (
+    GR00TN17Request,
+    GR00TN17WS1Scheduler,
+)
+
+
+__all__ = [
+    "GR00TN17ActionHead",
+    "GR00TN17ActionHeadConfig",
+    "GR00TN17ActionInput",
+    "GR00TN17Args",
+    "GR00TN17Backbone",
+    "GR00TN17BackboneConfig",
+    "GR00TN17BackboneOutput",
+    "GR00TN17Config",
+    "GR00TN17DiTConfig",
+    "GR00TN17Entry",
+    "GR00TN17Model",
+    "GR00TN17NativeImplementationError",
+    "GR00TN17ProcessorConfig",
+    "GR00TN17Request",
+    "GR00TN17VLSelfAttentionConfig",
+    "GR00TN17WS1Scheduler",
+    "gr00t_n17_weight_remap",
+]

--- a/phyai/src/phyai/models/gr00t_n17/configuration_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/configuration_gr00t_n17.py
@@ -1,0 +1,401 @@
+"""Configs for GR00T-N1.7.
+
+The public Isaac-GR00T N1.7 checkpoint stores a mostly flat
+``config.json``. PhyAI keeps the same defaults but groups them by the
+runtime boundary we implement:
+
+* processor: observation/action interpretation and preprocessing knobs;
+* backbone: Cosmos-Reason2 / Qwen3-VL feature extractor knobs;
+* action head: state/action encoders, optional VL self-attention, and DiT.
+
+Checkpoint-specific choices such as LIBERO vs DROID do not live in the
+modeling classes. They are selected by ``embodiment_tag`` and checkpoint
+processor metadata at runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from phyai.models.configuration import PretrainedConfig
+from phyai.models.qwen3_vl.configuration_qwen3_vl import (
+    Qwen3VLConfig,
+    Qwen3VLTextConfig,
+    Qwen3VLVisionConfig,
+)
+
+
+def _default_gr00t_qwen3vl_config() -> Qwen3VLConfig:
+    """Native Cosmos-Reason2/Qwen3-VL config used by GR00T-N1.7.
+
+    These values mirror the ``nvidia/Cosmos-Reason2-2B`` config referenced by
+    the public GR00T-N1.7 checkpoint, so the native backbone can be built
+    without resolving the HuggingFace repo at model-load time.
+    """
+    return Qwen3VLConfig(
+        vision=Qwen3VLVisionConfig(
+            depth=24,
+            hidden_size=1024,
+            hidden_act="gelu_pytorch_tanh",
+            intermediate_size=4096,
+            num_heads=16,
+            in_channels=3,
+            patch_size=16,
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+            out_hidden_size=2048,
+            num_position_embeddings=2304,
+            deepstack_visual_indexes=(5, 11, 17),
+            initializer_range=0.02,
+        ),
+        text=Qwen3VLTextConfig(
+            vocab_size=151936,
+            hidden_size=2048,
+            intermediate_size=6144,
+            num_hidden_layers=28,
+            num_attention_heads=16,
+            num_key_value_heads=8,
+            head_dim=128,
+            hidden_act="silu",
+            rms_norm_eps=1e-6,
+            rope_theta=5000000.0,
+            mrope_section=(24, 20, 20),
+            max_position_embeddings=262144,
+            attention_bias=False,
+            tie_word_embeddings=True,
+        ),
+        image_token_id=151655,
+        video_token_id=151656,
+        vision_start_token_id=151652,
+        vision_end_token_id=151653,
+        tie_word_embeddings=True,
+    )
+
+
+def _tuple2(v: object) -> tuple[int, int] | None:
+    if v is None:
+        return None
+    if isinstance(v, tuple) and len(v) == 2:
+        return (int(v[0]), int(v[1]))
+    if isinstance(v, list) and len(v) == 2:
+        return (int(v[0]), int(v[1]))
+    raise ValueError(f"expected a 2-item tuple/list or None, got {v!r}.")
+
+
+def _tuple_ints(v: object) -> tuple[int, ...]:
+    if isinstance(v, tuple):
+        return tuple(int(x) for x in v)
+    if isinstance(v, list):
+        return tuple(int(x) for x in v)
+    raise ValueError(f"expected a tuple/list of ints, got {v!r}.")
+
+
+@dataclass(frozen=True)
+class GR00TN17ProcessorConfig(PretrainedConfig):
+    """Processor and state/action normalization knobs."""
+
+    image_crop_size: tuple[int, int] | None = (230, 230)
+    image_target_size: tuple[int, int] | None = (256, 256)
+    shortest_image_edge: int | None = None
+    crop_fraction: float | None = None
+    random_rotation_angle: int | None = None
+    color_jitter_params: dict[str, float] | None = None
+    use_albumentations_transforms: bool = True
+    extra_augmentation_config: dict[str, Any] | None = None
+    formalize_language: bool = True
+    apply_sincos_state_encoding: bool = False
+    use_percentiles: bool = True
+    use_relative_action: bool = False
+    use_mean_std: bool = False
+    state_dropout_prob: float = 0.8
+    exclude_state: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "image_crop_size", _tuple2(self.image_crop_size))
+        object.__setattr__(
+            self, "image_target_size", _tuple2(self.image_target_size)
+        )
+        if self.shortest_image_edge is not None and self.shortest_image_edge <= 0:
+            raise ValueError("shortest_image_edge must be positive when set.")
+        if self.crop_fraction is not None and self.crop_fraction <= 0:
+            raise ValueError("crop_fraction must be positive when set.")
+        if not 0 <= self.state_dropout_prob <= 1:
+            raise ValueError("state_dropout_prob must be in [0, 1].")
+
+
+@dataclass(frozen=True)
+class GR00TN17BackboneConfig(PretrainedConfig):
+    """Cosmos-Reason2 / Qwen3-VL backbone knobs."""
+
+    model_name: str = "nvidia/Cosmos-Reason2-2B"
+    qwen3vl: Qwen3VLConfig | None = field(
+        default_factory=_default_gr00t_qwen3vl_config
+    )
+    backbone_model_type: str = "qwen"
+    model_revision: str | None = None
+    backbone_embedding_dim: int = 2048
+    tune_top_llm_layers: int = 0
+    tune_llm: bool = False
+    tune_visual: bool = False
+    select_layer: int = 12
+    reproject_vision: bool = False
+    use_flash_attention: bool = True
+    load_bf16: bool = False
+    backbone_trainable_params_fp32: bool = True
+    use_native_qwen3vl: bool = True
+    # Native Qwen3-VL no-cache attention backend. "sdpa" preserves the
+    # previous PyTorch SDPA numerics; "eager"/"flashinfer" are opt-in.
+    attention_backend: str = "sdpa"
+    # CUDA-graph sequence buckets for the native Qwen3-VL text side. The
+    # official GR00T config caps VL/action sequence handling at max_seq_len=1024.
+    # LIBERO's canonical two-camera prompt is 156 tokens, hence the 160 bucket;
+    # larger buckets cover future embodiments without always paying the full
+    # 1024-token dense LLM/action-head cost.
+    graph_seq_len_buckets: tuple[int, ...] = (160, 192, 256, 384, 512, 768, 1024)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GR00TN17BackboneConfig":
+        payload = {k: v for k, v in data.items() if k in cls.field_names()}
+        if isinstance(payload.get("qwen3vl"), dict):
+            payload["qwen3vl"] = Qwen3VLConfig.from_dict(payload["qwen3vl"])
+        return cls(**payload)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "graph_seq_len_buckets",
+            _tuple_ints(self.graph_seq_len_buckets),
+        )
+        if not self.model_name:
+            raise ValueError("model_name must be non-empty.")
+        if self.backbone_embedding_dim <= 0:
+            raise ValueError("backbone_embedding_dim must be positive.")
+        if self.tune_top_llm_layers < 0:
+            raise ValueError("tune_top_llm_layers must be non-negative.")
+        if self.attention_backend not in {"eager", "sdpa", "flashinfer"}:
+            raise ValueError(
+                "backbone.attention_backend must be one of: eager, sdpa, flashinfer."
+            )
+        if not self.graph_seq_len_buckets:
+            raise ValueError("backbone.graph_seq_len_buckets must not be empty.")
+        if any(bucket <= 0 for bucket in self.graph_seq_len_buckets):
+            raise ValueError("backbone.graph_seq_len_buckets must all be positive.")
+        if tuple(sorted(set(self.graph_seq_len_buckets))) != self.graph_seq_len_buckets:
+            raise ValueError(
+                "backbone.graph_seq_len_buckets must be unique and sorted ascending."
+            )
+
+
+@dataclass(frozen=True)
+class GR00TN17DiTConfig(PretrainedConfig):
+    """Diffusion transformer config inside the GR00T action head."""
+
+    positional_embeddings: str | None = None
+    num_layers: int = 16
+    num_attention_heads: int = 32
+    attention_head_dim: int = 48
+    norm_type: str = "ada_norm"
+    norm_elementwise_affine: bool = False
+    dropout: float = 0.2
+    final_dropout: bool = True
+    output_dim: int = 1024
+    interleave_self_attention: bool = True
+    # Dense no-cache attention backend used inside GR00T's action head.
+    # Default "sdpa" (phyai's recommended F.scaled_dot_product_attention), using
+    # PyTorch's normal SDPA dispatch (flash / mem-efficient). CUDA-graph
+    # captureable. Parity vs the reference: plain sdpa ~0.0221. For tighter parity
+    # set ``PHYAI_GR00T_DIT_SDPA_MATH=1`` to force the math backend (mirroring the
+    # official DiT's ``enable_flash=False`` / ``GR00T_DIT_SDPA_MODE=math``) ->
+    # ~0.0190. Neither is byte-exact: "eager" does the softmax in fp32 and is the
+    # only 0.0166 path (selected explicitly for parity validation). "flashinfer"
+    # is supported for unmasked self-attention; masked cross-attn falls back to
+    # the sdpa path (GR00T uses key-only masks).
+    attention_backend: str = "sdpa"
+
+    def __post_init__(self) -> None:
+        if self.num_layers <= 0:
+            raise ValueError("num_layers must be positive.")
+        if self.num_attention_heads <= 0:
+            raise ValueError("num_attention_heads must be positive.")
+        if self.attention_head_dim <= 0:
+            raise ValueError("attention_head_dim must be positive.")
+        if self.output_dim <= 0:
+            raise ValueError("output_dim must be positive.")
+        if not 0 <= self.dropout < 1:
+            raise ValueError("dropout must be in [0, 1).")
+        if self.attention_backend not in {"eager", "sdpa", "flashinfer"}:
+            raise ValueError(
+                "attention_backend must be one of: eager, sdpa, flashinfer."
+            )
+
+
+@dataclass(frozen=True)
+class GR00TN17VLSelfAttentionConfig(PretrainedConfig):
+    """Optional VL self-attention stack before the action head."""
+
+    num_layers: int = 0
+    num_attention_heads: int = 32
+    attention_head_dim: int = 64
+    dropout: float = 0.2
+    final_dropout: bool = True
+    positional_embeddings: str | None = None
+    output_dim: int | None = None
+    # Same backend policy as GR00TN17DiTConfig.attention_backend.
+    attention_backend: str = "sdpa"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GR00TN17VLSelfAttentionConfig":
+        return cls(**{k: v for k, v in data.items() if k in cls.field_names()})
+
+    def __post_init__(self) -> None:
+        if self.num_layers < 0:
+            raise ValueError("num_layers must be non-negative.")
+        if self.num_attention_heads <= 0:
+            raise ValueError("num_attention_heads must be positive.")
+        if self.attention_head_dim <= 0:
+            raise ValueError("attention_head_dim must be positive.")
+        if not 0 <= self.dropout < 1:
+            raise ValueError("dropout must be in [0, 1).")
+        if self.attention_backend not in {"eager", "sdpa", "flashinfer"}:
+            raise ValueError(
+                "attention_backend must be one of: eager, sdpa, flashinfer."
+            )
+
+
+@dataclass(frozen=True)
+class GR00TN17ActionHeadConfig(PretrainedConfig):
+    """GR00T flow-matching action head config."""
+
+    max_state_dim: int = 132
+    max_action_dim: int = 132
+    action_horizon: int = 40
+    hidden_size: int = 1024
+    input_embedding_dim: int = 1536
+    state_history_length: int = 1
+    add_pos_embed: bool = True
+    attn_dropout: float = 0.2
+    use_vlln: bool = True
+    max_seq_len: int = 1024
+    use_alternate_vl_dit: bool = True
+    attend_text_every_n_blocks: int = 2
+    max_num_embodiments: int = 32
+    num_inference_timesteps: int = 4
+    noise_beta_alpha: float = 1.5
+    noise_beta_beta: float = 1.0
+    noise_s: float = 0.999
+    num_timestep_buckets: int = 1000
+    tune_projector: bool = True
+    tune_diffusion_model: bool = True
+    tune_vlln: bool = True
+    dit: GR00TN17DiTConfig = field(default_factory=GR00TN17DiTConfig)
+    vl_self_attention: GR00TN17VLSelfAttentionConfig | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GR00TN17ActionHeadConfig":
+        payload = {k: v for k, v in data.items() if k in cls.field_names()}
+        if isinstance(payload.get("dit"), dict):
+            payload["dit"] = GR00TN17DiTConfig.from_dict(payload["dit"])
+        if isinstance(payload.get("vl_self_attention"), dict):
+            payload["vl_self_attention"] = GR00TN17VLSelfAttentionConfig.from_dict(
+                payload["vl_self_attention"]
+            )
+        return cls(**payload)
+
+    def __post_init__(self) -> None:
+        if self.max_state_dim <= 0:
+            raise ValueError("max_state_dim must be positive.")
+        if self.max_action_dim <= 0:
+            raise ValueError("max_action_dim must be positive.")
+        if self.action_horizon <= 0:
+            raise ValueError("action_horizon must be positive.")
+        if self.hidden_size <= 0:
+            raise ValueError("hidden_size must be positive.")
+        if self.input_embedding_dim <= 0:
+            raise ValueError("input_embedding_dim must be positive.")
+        if self.state_history_length <= 0:
+            raise ValueError("state_history_length must be positive.")
+        if not 0 <= self.attn_dropout < 1:
+            raise ValueError("attn_dropout must be in [0, 1).")
+        if self.max_seq_len <= 0:
+            raise ValueError("max_seq_len must be positive.")
+        if self.attend_text_every_n_blocks <= 0:
+            raise ValueError("attend_text_every_n_blocks must be positive.")
+        if self.max_num_embodiments <= 0:
+            raise ValueError("max_num_embodiments must be positive.")
+        if self.num_inference_timesteps <= 0:
+            raise ValueError("num_inference_timesteps must be positive.")
+        if self.num_timestep_buckets <= 0:
+            raise ValueError("num_timestep_buckets must be positive.")
+
+
+@dataclass(frozen=True)
+class GR00TN17Config(PretrainedConfig):
+    """Top-level GR00T-N1.7 inference config."""
+
+    model_type: str = "Gr00tN1d7"
+    model_dtype: str = "bfloat16"
+    processor: GR00TN17ProcessorConfig = field(
+        default_factory=GR00TN17ProcessorConfig
+    )
+    backbone: GR00TN17BackboneConfig = field(default_factory=GR00TN17BackboneConfig)
+    action_head: GR00TN17ActionHeadConfig = field(
+        default_factory=GR00TN17ActionHeadConfig
+    )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GR00TN17Config":
+        """Load either PhyAI nested configs or upstream flat GR00T JSON."""
+        if any(k in data for k in ("processor", "backbone", "action_head")):
+            processor = GR00TN17ProcessorConfig.from_dict(data.get("processor", {}))
+            backbone = GR00TN17BackboneConfig.from_dict(data.get("backbone", {}))
+            action_head = GR00TN17ActionHeadConfig.from_dict(
+                data.get("action_head", {})
+            )
+            return cls(
+                model_type=data.get("model_type", "Gr00tN1d7"),
+                model_dtype=data.get("model_dtype", "bfloat16"),
+                processor=processor,
+                backbone=backbone,
+                action_head=action_head,
+            )
+
+        processor = GR00TN17ProcessorConfig.from_dict(data)
+        backbone = GR00TN17BackboneConfig.from_dict(data)
+        dit = GR00TN17DiTConfig.from_dict(data.get("diffusion_model_cfg", {}))
+        vl_self_attention = None
+        if (raw := data.get("vl_self_attention_cfg")) is not None:
+            vl_self_attention = GR00TN17VLSelfAttentionConfig.from_dict(raw)
+        action_payload = {
+            k: v for k, v in data.items() if k in GR00TN17ActionHeadConfig.field_names()
+        }
+        action_payload["dit"] = dit
+        action_payload["vl_self_attention"] = vl_self_attention
+        action_head = GR00TN17ActionHeadConfig.from_dict(action_payload)
+        return cls(
+            model_type=data.get("model_type", "Gr00tN1d7"),
+            model_dtype=data.get("model_dtype", "bfloat16"),
+            processor=processor,
+            backbone=backbone,
+            action_head=action_head,
+        )
+
+    def __post_init__(self) -> None:
+        if self.model_type != "Gr00tN1d7":
+            raise ValueError(f"expected model_type='Gr00tN1d7', got {self.model_type!r}.")
+        if not self.model_dtype:
+            raise ValueError("model_dtype must be non-empty.")
+        if self.action_head.dit.output_dim != self.action_head.hidden_size:
+            raise ValueError(
+                "action_head.dit.output_dim must equal action_head.hidden_size."
+            )
+
+
+__all__ = [
+    "GR00TN17ActionHeadConfig",
+    "GR00TN17BackboneConfig",
+    "GR00TN17Config",
+    "GR00TN17DiTConfig",
+    "GR00TN17ProcessorConfig",
+    "GR00TN17VLSelfAttentionConfig",
+]

--- a/phyai/src/phyai/models/gr00t_n17/configuration_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/configuration_gr00t_n17.py
@@ -113,9 +113,7 @@ class GR00TN17ProcessorConfig(PretrainedConfig):
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "image_crop_size", _tuple2(self.image_crop_size))
-        object.__setattr__(
-            self, "image_target_size", _tuple2(self.image_target_size)
-        )
+        object.__setattr__(self, "image_target_size", _tuple2(self.image_target_size))
         if self.shortest_image_edge is not None and self.shortest_image_edge <= 0:
             raise ValueError("shortest_image_edge must be positive when set.")
         if self.crop_fraction is not None and self.crop_fraction <= 0:
@@ -129,9 +127,7 @@ class GR00TN17BackboneConfig(PretrainedConfig):
     """Cosmos-Reason2 / Qwen3-VL backbone knobs."""
 
     model_name: str = "nvidia/Cosmos-Reason2-2B"
-    qwen3vl: Qwen3VLConfig | None = field(
-        default_factory=_default_gr00t_qwen3vl_config
-    )
+    qwen3vl: Qwen3VLConfig | None = field(default_factory=_default_gr00t_qwen3vl_config)
     backbone_model_type: str = "qwen"
     model_revision: str | None = None
     backbone_embedding_dim: int = 2048
@@ -335,9 +331,7 @@ class GR00TN17Config(PretrainedConfig):
 
     model_type: str = "Gr00tN1d7"
     model_dtype: str = "bfloat16"
-    processor: GR00TN17ProcessorConfig = field(
-        default_factory=GR00TN17ProcessorConfig
-    )
+    processor: GR00TN17ProcessorConfig = field(default_factory=GR00TN17ProcessorConfig)
     backbone: GR00TN17BackboneConfig = field(default_factory=GR00TN17BackboneConfig)
     action_head: GR00TN17ActionHeadConfig = field(
         default_factory=GR00TN17ActionHeadConfig
@@ -382,7 +376,9 @@ class GR00TN17Config(PretrainedConfig):
 
     def __post_init__(self) -> None:
         if self.model_type != "Gr00tN1d7":
-            raise ValueError(f"expected model_type='Gr00tN1d7', got {self.model_type!r}.")
+            raise ValueError(
+                f"expected model_type='Gr00tN1d7', got {self.model_type!r}."
+            )
         if not self.model_dtype:
             raise ValueError("model_dtype must be non-empty.")
         if self.action_head.dit.output_dim != self.action_head.hidden_size:

--- a/phyai/src/phyai/models/gr00t_n17/main_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/main_gr00t_n17.py
@@ -1,0 +1,179 @@
+"""GR00T-N1.7 engine plugin entry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, ClassVar
+
+import torch
+
+from phyai.engine import Engine, Entry, EntryArgs
+from phyai.engine_config import get_engine_config
+from phyai.models.gr00t_n17.configuration_gr00t_n17 import GR00TN17Config
+from phyai.models.gr00t_n17.modeling_gr00t_n17 import GR00TN17Model
+from phyai.models.gr00t_n17.scheduler_ws1_gr00t_n17 import (
+    GR00TN17Request,
+    GR00TN17WS1Scheduler,
+)
+from phyai.utils import load_config
+from phyai.weights import load_pretrained
+
+
+_GR00TN17_PENDING_DROP_PREFIXES: tuple[str, ...] = ()
+
+
+def gr00t_n17_weight_remap(name: str) -> str | None:
+    """Map a GR00T-N1.7 checkpoint key to its phyai parameter key.
+
+    The native GR00T-N1.7 checkpoint keys already match the phyai parameters
+    (each parameter carries its own ``hf_keys``), so this is identity except for
+    keys under :data:`_GR00TN17_PENDING_DROP_PREFIXES`, which return ``None``
+    (dropped). Follows the ``<model>_weight_remap`` convention.
+    """
+    if name.startswith(_GR00TN17_PENDING_DROP_PREFIXES):
+        return None
+    return name
+
+
+def _compose_remap(
+    user_remap: Callable[[str], str | None] | dict[str, str] | None,
+) -> Callable[[str], str | None]:
+    """Compose :func:`gr00t_n17_weight_remap` with an optional user remap."""
+    if user_remap is None:
+        return gr00t_n17_weight_remap
+    if callable(user_remap):
+
+        def _chained(k: str) -> str | None:
+            mapped = gr00t_n17_weight_remap(k)
+            if mapped is None:
+                return None
+            return user_remap(mapped)
+
+        return _chained
+    if isinstance(user_remap, dict):
+        rules = list(user_remap.items())
+
+        def _chained_dict(k: str) -> str | None:
+            mapped = gr00t_n17_weight_remap(k)
+            if mapped is None:
+                return None
+            for src, dst in rules:
+                if src in mapped:
+                    mapped = mapped.replace(src, dst)
+            return mapped
+
+        return _chained_dict
+    raise TypeError(
+        f"weight_remap must be callable, dict, or None; got {type(user_remap).__name__}"
+    )
+
+
+@dataclass
+class GR00TN17Args(EntryArgs):
+    """Args bundle for the GR00T-N1.7 plugin.
+
+    ``checkpoint_dir`` is optional for import/shape-only development.
+    When provided, ``config.json`` is loaded from that directory and
+    safetensors are loaded into the native model.
+
+    The engine consumes already-prepared model-input tensors (see
+    :class:`GR00TN17Request`); image transform, Qwen3-VL patchify,
+    tokenization, and state/action normalization are the caller's job via
+    ``phyai_utils_tools.models.gr00t.GR00TProcessor``. Hence there is no
+    ``embodiment_tag`` / processor knob here — those live with the processor.
+    """
+
+    checkpoint_dir: str | Path | None = None
+    config: GR00TN17Config | None = None
+    max_batch_size: int = 1
+    weight_remap: Callable[[str], str | None] | dict[str, str] | None = None
+    weight_strict: bool = True
+    backbone_model_name_or_path: str | Path | None = None
+    backbone_transformers_loading_kwargs: dict[str, Any] | None = None
+
+
+@Engine.register
+class GR00TN17Entry(Entry):
+    """GR00T-N1.7 inference plugin entry."""
+
+    name: ClassVar[str] = "gr00t_n17"
+    args_cls: ClassVar[type[EntryArgs]] = GR00TN17Args
+
+    def __init__(self) -> None:
+        self.model: GR00TN17Model | None = None
+        self.scheduler: GR00TN17WS1Scheduler | None = None
+
+    def setup(self, args: EntryArgs) -> None:
+        if not isinstance(args, GR00TN17Args):
+            raise TypeError(
+                "GR00TN17Entry.setup expected GR00TN17Args, got "
+                f"{type(args).__name__}."
+            )
+        eng = get_engine_config()
+        if args.config is not None:
+            config = args.config
+        elif args.checkpoint_dir is not None:
+            config = load_config(args.checkpoint_dir, GR00TN17Config)
+        else:
+            config = GR00TN17Config()
+        if args.backbone_model_name_or_path is not None:
+            config = replace(
+                config,
+                backbone=replace(
+                    config.backbone,
+                    model_name=str(args.backbone_model_name_or_path),
+                    qwen3vl=None,
+                ),
+            )
+
+        self.model = GR00TN17Model(
+            config,
+            params_dtype=eng.device.params_dtype,
+            device=eng.device.target,
+            backbone_transformers_loading_kwargs=args.backbone_transformers_loading_kwargs,
+        )
+
+        if args.checkpoint_dir is not None:
+            self.model.backbone._load_qwen3vl_model()
+            load_pretrained(
+                self.model,
+                args.checkpoint_dir,
+                remap=_compose_remap(args.weight_remap),
+                strict=args.weight_strict,
+            )
+
+        self.scheduler = GR00TN17WS1Scheduler(
+            self.model,
+            max_batch_size=args.max_batch_size,
+            device=eng.device.target,
+            use_cuda_graph=eng.runtime.use_cuda_graph,
+        )
+        self.scheduler.setup()
+
+    def step(self, request: GR00TN17Request) -> torch.Tensor:
+        if self.scheduler is None:
+            raise RuntimeError("GR00TN17Entry.step called before setup.")
+        return self.scheduler.step(request)
+
+    def close(self) -> None:
+        if self.scheduler is not None:
+            self.scheduler.close()
+            self.scheduler = None
+        self.model = None
+
+    def dump_targets(self) -> dict[str, torch.nn.Module]:
+        """Expose the GR00T-N1.7 model for engine-driven tensor dumping.
+
+        Returns ``{"model": self.model}`` so dumped operator keys read
+        ``model.backbone.qwen3vl_model.model.language_model.layers.0...`` and
+        ``model.action_head...`` (aligned with the checkpoint parameter names).
+        Returns ``{}`` before :meth:`setup` has built the model, so a
+        dump-enabled engine that queries early records nothing instead of crashing.
+        """
+        if self.model is None:
+            return {}
+        return {"model": self.model}
+
+
+__all__ = ["GR00TN17Args", "GR00TN17Entry"]

--- a/phyai/src/phyai/models/gr00t_n17/model_runner_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/model_runner_gr00t_n17.py
@@ -1,0 +1,307 @@
+"""GR00T-N1.7 model runner boundaries.
+
+Runners will eventually own CUDA graph capture for the backbone and
+action head. The first native drop keeps these boundaries explicit and
+raises before silently falling back to the reference implementation.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from phyai.models.gr00t_n17.modeling_gr00t_n17 import (
+    GR00TN17ActionInput,
+    GR00TN17BackboneOutput,
+    GR00TN17Model,
+    gr00t_n17_static_category_ids,
+)
+from phyai.runtime.cuda_graph_manager import CudaGraph, CudaGraphRegistry
+from phyai.runtime.model_runner import ModelRunner
+
+
+_BACKBONE_CUDA_GRAPH_ENV = "PHYAI_GR00T_BACKBONE_CUDA_GRAPH"
+
+
+def _backbone_cuda_graph_enabled() -> bool:
+    """Whether to CUDA-graph the Qwen3-VL backbone (ViT / LLM cores).
+
+    This flag is off by default to keep a reference/eager comparison path. The
+    optimized GR00T benchmark path enables it with a truthy
+    ``PHYAI_GR00T_BACKBONE_CUDA_GRAPH`` (1/on/true/yes), so the fixed-shape
+    ViT -> multimodal-fuse -> LLM stream is captured and replayed.
+    """
+    return os.environ.get(_BACKBONE_CUDA_GRAPH_ENV, "").strip().lower() in {
+        "1",
+        "on",
+        "true",
+        "yes",
+    }
+
+
+class GR00TN17BackboneRunner(ModelRunner):
+    """Runs the Qwen3-VL backbone and owns its CUDA graph.
+
+    Gated by ``PHYAI_GR00T_BACKBONE_CUDA_GRAPH``: the default path is eager for
+    reference parity, while the benchmark/optimized path enables graph replay.
+    When enabled and graph-eligible, the whole ViT -> multimodal-fuse -> LLM
+    decoder is captured/replayed **here** as one shape-keyed graph: the modeling
+    exposes a pure preamble + core via
+    ``GR00TN17Backbone.backbone_graph_plan`` and holds no graph state .
+
+    Lifecycle: no per-request mutable state, hence no ``reset()`` (the base
+    :class:`ModelRunner` defines only ``setup``/``forward``; ``reset`` is not part
+    of the contract and no runner here implements one). The only cross-call state
+    is the shape-keyed graph registry, intentionally reused across requests and
+    released in :meth:`close`.
+    """
+
+    def __init__(self, model: GR00TN17Model) -> None:
+        self.model = model
+        self.graphs = CudaGraphRegistry()
+
+    def setup(self) -> None:
+        return None
+
+    def _replay_or_capture(self, core_fn, inputs: dict, key: tuple) -> torch.Tensor:
+        graph = self.graphs.get(key)
+        if graph is None:
+            graph = CudaGraph()
+            graph.capture(core_fn, inputs)
+            self.graphs.register(key, graph)
+        out = graph.replay(inputs)
+        # Replay output aliases the static capture buffer; clone the pre-norm
+        # features that leave to the action head this step.
+        return out.pre_norm_hidden_state.clone()
+
+    def forward(self, inputs) -> GR00TN17BackboneOutput:
+        backbone_inputs = dict(inputs)
+        if "position_ids" not in backbone_inputs:
+            position_ids = self.model.backbone.prepare_position_ids(backbone_inputs)
+            if position_ids is not None:
+                backbone_inputs["position_ids"] = position_ids
+        backbone = self.model.backbone
+        if _backbone_cuda_graph_enabled():
+            plan = backbone.backbone_graph_plan(backbone_inputs)
+            if plan is not None:
+                core_fn, buffers, key, model_inputs = plan
+                features = self._replay_or_capture(core_fn, buffers, key)
+                return backbone.build_graph_output(features, model_inputs)
+        return backbone.forward(backbone_inputs)
+
+    def close(self) -> None:
+        self.graphs = CudaGraphRegistry()
+        return None
+
+
+class GR00TN17ActionHeadRunner(ModelRunner):
+    """Runs the state/action encoders and DiT denoising loop.
+
+    Lifecycle: like the backbone runner, it keeps no per-request mutable state
+    (the constructor flags and the shape-keyed graph registry are the only state,
+    reused across requests and released in :meth:`close`), so it needs no
+    ``reset()`` — which the base :class:`ModelRunner` contract does not define.
+    """
+
+    @staticmethod
+    def _supports_cuda_graph_attention(model: GR00TN17Model) -> bool:
+        action_config = model.action_head.config
+        if action_config.dit.attention_backend == "flashinfer":
+            return False
+        vl_self_attention = action_config.vl_self_attention
+        if (
+            vl_self_attention is not None
+            and vl_self_attention.attention_backend == "flashinfer"
+        ):
+            return False
+        return True
+
+    def __init__(
+        self,
+        model: GR00TN17Model,
+        *,
+        max_batch_size: int = 1,
+        device: torch.device | str | None = None,
+        use_cuda_graph: bool = True,
+    ) -> None:
+        self.model = model
+        self.max_batch_size = int(max_batch_size)
+        self.device = torch.device(device) if device is not None else torch.device("cpu")
+        self.use_cuda_graph = (
+            bool(use_cuda_graph)
+            and self.device.type == "cuda"
+            and self._supports_cuda_graph_attention(model)
+        )
+        self.graphs = CudaGraphRegistry()
+
+    def setup(self) -> None:
+        return None
+
+    def _shape_key(
+        self,
+        backbone_output: GR00TN17BackboneOutput,
+        action_input: GR00TN17ActionInput,
+        noise: torch.Tensor,
+    ) -> tuple[object, ...]:
+        return (
+            tuple(backbone_output.backbone_features.shape),
+            backbone_output.backbone_features.dtype,
+            tuple(backbone_output.backbone_attention_mask.shape),
+            tuple(action_input.state.shape),
+            action_input.state.dtype,
+            tuple(action_input.embodiment_id.shape),
+            tuple(noise.shape),
+            noise.dtype,
+        )
+
+    @staticmethod
+    def _category_key(action_input: GR00TN17ActionInput) -> tuple[int, ...] | None:
+        cat_ids = action_input.embodiment_id
+        if cat_ids.ndim != 1:
+            return None
+        return tuple(int(v) for v in cat_ids.detach().cpu().tolist())
+
+    def _prepare_noise(
+        self,
+        backbone_output: GR00TN17BackboneOutput,
+        noise: torch.Tensor | None,
+    ) -> torch.Tensor:
+        return self.model.action_head.prepare_initial_actions(
+            backbone_output.backbone_features,
+            noise=noise,
+        )
+
+    def _image_mask_tensor(
+        self,
+        backbone_output: GR00TN17BackboneOutput,
+    ) -> torch.Tensor:
+        if backbone_output.image_mask is not None:
+            return backbone_output.image_mask
+        return torch.zeros_like(
+            backbone_output.backbone_attention_mask,
+            dtype=torch.bool,
+        )
+
+    def _fwd_loop(
+        self,
+        *,
+        backbone_features: torch.Tensor,
+        backbone_attention_mask: torch.Tensor,
+        image_mask: torch.Tensor,
+        state: torch.Tensor,
+        embodiment_id: torch.Tensor,
+        noise: torch.Tensor,
+    ) -> torch.Tensor:
+        backbone_output = GR00TN17BackboneOutput(
+            backbone_features=backbone_features,
+            backbone_attention_mask=backbone_attention_mask,
+            image_mask=image_mask,
+        )
+        action_input = GR00TN17ActionInput(
+            state=state,
+            embodiment_id=embodiment_id,
+        )
+        action_head = self.model.action_head
+        backbone_features, state_features = action_head._encode_features(
+            backbone_output, action_input
+        )
+        actions = action_head.prepare_initial_actions(backbone_features, noise=noise)
+        encoder_kv_cache = action_head.precompute_dit_encoder_kv(backbone_features)
+        for step in range(action_head.num_inference_timesteps):
+            actions = action_head.denoise_step(
+                actions,
+                step,
+                backbone_features=backbone_features,
+                state_features=state_features,
+                embodiment_id=action_input.embodiment_id,
+                backbone_output=backbone_output,
+                action_input=action_input,
+                encoder_kv_cache=encoder_kv_cache,
+            )
+        return actions
+
+    def _static_category_fwd_loop(
+        self,
+        *,
+        category_key: tuple[int, ...],
+        backbone_features: torch.Tensor,
+        backbone_attention_mask: torch.Tensor,
+        image_mask: torch.Tensor,
+        state: torch.Tensor,
+        embodiment_id: torch.Tensor,
+        noise: torch.Tensor,
+    ) -> torch.Tensor:
+        with gr00t_n17_static_category_ids(category_key):
+            return self._fwd_loop(
+                backbone_features=backbone_features,
+                backbone_attention_mask=backbone_attention_mask,
+                image_mask=image_mask,
+                state=state,
+                embodiment_id=embodiment_id,
+                noise=noise,
+            )
+
+    def _graph_inputs(
+        self,
+        backbone_output: GR00TN17BackboneOutput,
+        action_input: GR00TN17ActionInput,
+        noise: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        return {
+            "backbone_features": backbone_output.backbone_features,
+            "backbone_attention_mask": backbone_output.backbone_attention_mask,
+            "image_mask": self._image_mask_tensor(backbone_output),
+            "state": action_input.state,
+            "embodiment_id": action_input.embodiment_id,
+            "noise": noise,
+        }
+
+    def forward(
+        self,
+        backbone_output: GR00TN17BackboneOutput,
+        action_input: GR00TN17ActionInput,
+        *,
+        noise=None,
+    ):
+        if action_input.action is not None:
+            return self.model.action_head.get_action(
+                backbone_output,
+                action_input,
+                noise=noise,
+            )
+        if backbone_output.backbone_features.shape[0] > self.max_batch_size:
+            raise ValueError(
+                "GR00T-N1.7 action runner batch exceeds max_batch_size: "
+                f"{backbone_output.backbone_features.shape[0]} > {self.max_batch_size}."
+            )
+        noise = self._prepare_noise(backbone_output, noise)
+        inputs = self._graph_inputs(backbone_output, action_input, noise)
+        if self.use_cuda_graph:
+            category_key = self._category_key(action_input)
+            key = self._shape_key(backbone_output, action_input, noise) + (
+                category_key,
+            )
+            graph = self.graphs.get(key)
+            if graph is None:
+                graph = CudaGraph()
+                if category_key is None:
+                    graph.capture(self._fwd_loop, inputs)
+                else:
+                    graph.capture(
+                        lambda **kwargs: self._static_category_fwd_loop(
+                            category_key=category_key,
+                            **kwargs,
+                        ),
+                        inputs,
+                    )
+                self.graphs.register(key, graph)
+            return graph.replay(inputs)
+        return self._fwd_loop(**inputs)
+
+    def close(self) -> None:
+        self.graphs = CudaGraphRegistry()
+        return None
+
+
+__all__ = ["GR00TN17ActionHeadRunner", "GR00TN17BackboneRunner"]

--- a/phyai/src/phyai/models/gr00t_n17/model_runner_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/model_runner_gr00t_n17.py
@@ -127,7 +127,9 @@ class GR00TN17ActionHeadRunner(ModelRunner):
     ) -> None:
         self.model = model
         self.max_batch_size = int(max_batch_size)
-        self.device = torch.device(device) if device is not None else torch.device("cpu")
+        self.device = (
+            torch.device(device) if device is not None else torch.device("cpu")
+        )
         self.use_cuda_graph = (
             bool(use_cuda_graph)
             and self.device.type == "cuda"

--- a/phyai/src/phyai/models/gr00t_n17/modeling_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/modeling_gr00t_n17.py
@@ -367,7 +367,12 @@ class GR00TN17Backbone(nn.Module):
         self, inputs: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         vl_input = self.prepare_input(inputs)
-        required_keys = ("input_ids", "attention_mask", "pixel_values", "image_grid_thw")
+        required_keys = (
+            "input_ids",
+            "attention_mask",
+            "pixel_values",
+            "image_grid_thw",
+        )
         optional_keys = (
             "mm_token_type_ids",
             "position_ids",
@@ -379,7 +384,9 @@ class GR00TN17Backbone(nn.Module):
         if missing:
             raise KeyError(f"backbone inputs missing keys: {missing}")
         model_inputs = {key: vl_input[key] for key in required_keys}
-        model_inputs.update({key: vl_input[key] for key in optional_keys if key in vl_input})
+        model_inputs.update(
+            {key: vl_input[key] for key in optional_keys if key in vl_input}
+        )
         self._ensure_qwen3vl_model_device(model_inputs["input_ids"].device)
         return model_inputs
 
@@ -444,10 +451,12 @@ def _swish(x: torch.Tensor) -> torch.Tensor:
 
 
 def _gelu_tanh(x: torch.Tensor) -> torch.Tensor:
-    return 0.5 * x * (
-        1.0
-        + torch.tanh(
-            math.sqrt(2.0 / math.pi) * (x + 0.044715 * torch.pow(x, 3))
+    return (
+        0.5
+        * x
+        * (
+            1.0
+            + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * torch.pow(x, 3)))
         )
     )
 
@@ -590,9 +599,7 @@ class GR00TN17SinusoidalPositionalEncoding(nn.Module):
                 f"{tuple(timesteps.shape)}."
             )
         half_dim = self.embedding_dim // 2
-        exponent = -torch.arange(
-            half_dim, dtype=torch.float32, device=timesteps.device
-        )
+        exponent = -torch.arange(half_dim, dtype=torch.float32, device=timesteps.device)
         exponent = exponent * (math.log(10000.0) / half_dim)
         freqs = timesteps.float().unsqueeze(-1) * exponent.exp()
         enc = torch.cat((torch.sin(freqs), torch.cos(freqs)), dim=-1)
@@ -628,7 +635,9 @@ class GR00TN17CategorySpecificLinear(nn.Module):
     def attach_hf_keys(self, prefix: str) -> None:
         """Load official stacked W/b tensors into per-embodiment linears."""
 
-        def _load_weight(_param: nn.Parameter, tensor: torch.Tensor, _shard_id: object) -> None:
+        def _load_weight(
+            _param: nn.Parameter, tensor: torch.Tensor, _shard_id: object
+        ) -> None:
             if tuple(tensor.shape) != (
                 self.num_categories,
                 self.input_dim,
@@ -647,7 +656,9 @@ class GR00TN17CategorySpecificLinear(nn.Module):
                     )
                 )
 
-        def _load_bias(_param: nn.Parameter, tensor: torch.Tensor, _shard_id: object) -> None:
+        def _load_bias(
+            _param: nn.Parameter, tensor: torch.Tensor, _shard_id: object
+        ) -> None:
             if tuple(tensor.shape) != (self.num_categories, self.output_dim):
                 raise ValueError(
                     f"{prefix}.b shape mismatch: expected "
@@ -686,8 +697,7 @@ class GR00TN17CategorySpecificLinear(nn.Module):
                     f"{len(static_cat_ids)} vs {x.shape[0]}."
                 )
             if any(
-                cat_id < 0 or cat_id >= self.num_categories
-                for cat_id in static_cat_ids
+                cat_id < 0 or cat_id >= self.num_categories for cat_id in static_cat_ids
             ):
                 raise ValueError(
                     f"static category ids must be in [0, {self.num_categories})."
@@ -855,7 +865,9 @@ class GR00TN17Attention(nn.Module):
         self.to_v = GR00TN17Linear(kv_dim, self.inner_dim, bias=bias)
         self.to_out = GR00TN17Linear(self.inner_dim, query_dim, bias=True)
         self.dropout = float(dropout)
-        backend_kwargs = {"compile": False} if self.attention_backend == "sdpa" else None
+        backend_kwargs = (
+            {"compile": False} if self.attention_backend == "sdpa" else None
+        )
         self.prefill_attention = Attention(
             self.num_heads,
             self.head_dim,
@@ -885,9 +897,7 @@ class GR00TN17Attention(nn.Module):
     ) -> torch.Tensor:
         scores = torch.matmul(q, k.transpose(-2, -1)) * self.scale
         if attention_mask is not None:
-            scores = scores.masked_fill(
-                ~attention_mask, torch.finfo(scores.dtype).min
-            )
+            scores = scores.masked_fill(~attention_mask, torch.finfo(scores.dtype).min)
         attn = torch.softmax(scores.float(), dim=-1).to(dtype=q.dtype)
         if attention_mask is not None:
             attn = attn * attention_mask.to(dtype=attn.dtype)
@@ -1094,9 +1104,7 @@ class GR00TN17DiT(nn.Module):
                 GR00TN17BasicTransformerBlock(
                     self.inner_dim,
                     config,
-                    cross_attention_dim=None
-                    if use_self_attn
-                    else cross_attention_dim,
+                    cross_attention_dim=None if use_self_attn else cross_attention_dim,
                 )
             )
         self.transformer_blocks = nn.ModuleList(blocks)
@@ -1156,9 +1164,9 @@ class GR00TN17DiT(nn.Module):
             all_hidden_states.append(hidden_states)
 
         shift, scale = self.proj_out_1(_swish(temb)).chunk(2, dim=1)
-        hidden_states = self.norm_out(hidden_states) * (1 + scale[:, None]) + shift[
-            :, None
-        ]
+        hidden_states = (
+            self.norm_out(hidden_states) * (1 + scale[:, None]) + shift[:, None]
+        )
         output = self.proj_out_2(hidden_states)
         if return_all_hidden_states:
             return output, all_hidden_states
@@ -1226,9 +1234,9 @@ class GR00TN17AlternateVLDiT(GR00TN17DiT):
             all_hidden_states.append(hidden_states)
 
         shift, scale = self.proj_out_1(_swish(temb)).chunk(2, dim=1)
-        hidden_states = self.norm_out(hidden_states) * (1 + scale[:, None]) + shift[
-            :, None
-        ]
+        hidden_states = (
+            self.norm_out(hidden_states) * (1 + scale[:, None]) + shift[:, None]
+        )
         output = self.proj_out_2(hidden_states)
         if return_all_hidden_states:
             return output, all_hidden_states
@@ -1296,9 +1304,7 @@ class GR00TN17SelfAttentionBlock(nn.Module):
             backend=attention_backend,
         )
         self.norm3 = GR00TN17LayerNorm(dim, eps=1e-5, elementwise_affine=True)
-        self.ff = GR00TN17FeedForward(
-            dim, dropout=dropout, final_dropout=final_dropout
-        )
+        self.ff = GR00TN17FeedForward(dim, dropout=dropout, final_dropout=final_dropout)
 
     def forward(
         self,
@@ -1435,7 +1441,9 @@ class GR00TN17ActionHead(nn.Module):
         state_features = self.state_encoder(state, action_input.embodiment_id)
         return backbone_output.backbone_features, state_features
 
-    def _positioned_action_features(self, action_features: torch.Tensor) -> torch.Tensor:
+    def _positioned_action_features(
+        self, action_features: torch.Tensor
+    ) -> torch.Tensor:
         if not self.config.add_pos_embed:
             return action_features
         if action_features.shape[1] > self.config.max_seq_len:

--- a/phyai/src/phyai/models/gr00t_n17/modeling_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/modeling_gr00t_n17.py
@@ -522,7 +522,7 @@ def _is_cuda_graph_capturing(x: torch.Tensor) -> bool:
 
 
 def _replicated_linear(linear: ReplicatedLinear, x: torch.Tensor) -> torch.Tensor:
-    out, bias = ReplicatedLinear.forward(linear, x)
+    out, bias = linear(x)
     if bias is not None:
         return out + bias
     return out
@@ -544,7 +544,10 @@ class GR00TN17Linear(ReplicatedLinear):
         _init_uniform_(self.bias, -bound, bound)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _replicated_linear(self, x)
+        out, bias = super().forward(x)
+        if bias is not None:
+            return out + bias
+        return out
 
 
 def _gr00t_n17_action_head_hf_key(local_name: str, prefix: str) -> str:
@@ -1146,7 +1149,7 @@ class GR00TN17DiT(nn.Module):
         all_hidden_states = [hidden_states]
         for idx, block in enumerate(self.transformer_blocks):
             encoder_kv = encoder_kv_cache[idx] if encoder_kv_cache is not None else None
-            if idx % 2 == 1 and self.config.interleave_self_attention:
+            if not block.is_cross_attention:
                 hidden_states = block(
                     hidden_states,
                     encoder_hidden_states=None,
@@ -1210,9 +1213,10 @@ class GR00TN17AlternateVLDiT(GR00TN17DiT):
         image_attention_mask = image_mask.bool() & backbone_attention_mask.bool()
         non_image_attention_mask = (~image_mask.bool()) & backbone_attention_mask.bool()
         all_hidden_states = [hidden_states]
+        cross_idx = 0
         for idx, block in enumerate(self.transformer_blocks):
             encoder_kv = encoder_kv_cache[idx] if encoder_kv_cache is not None else None
-            if idx % 2 == 1:
+            if not block.is_cross_attention:
                 hidden_states = block(
                     hidden_states,
                     encoder_hidden_states=None,
@@ -1220,10 +1224,11 @@ class GR00TN17AlternateVLDiT(GR00TN17DiT):
                     temb=temb,
                 )
             else:
-                if idx % (2 * self.attend_text_every_n_blocks) == 0:
+                if cross_idx % self.attend_text_every_n_blocks == 0:
                     curr_mask = non_image_attention_mask
                 else:
                     curr_mask = image_attention_mask
+                cross_idx += 1
                 hidden_states = block(
                     hidden_states,
                     encoder_hidden_states=encoder_hidden_states,

--- a/phyai/src/phyai/models/gr00t_n17/modeling_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/modeling_gr00t_n17.py
@@ -1,0 +1,1688 @@
+"""GR00T-N1.7 native model boundaries.
+
+This module intentionally mirrors the decomposition in Isaac-GR00T N1.7
+without importing the reference implementation:
+
+* Qwen3-VL / Cosmos backbone: produces V-L token features.
+* Action head: state encoder, action encoder, optional VL self-attn,
+  DiT, action decoder.
+* Top-level container: owns parameters only; runners/scheduler own
+  runtime state, random noise, denoising loops, and graph capture.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from contextvars import ContextVar
+from dataclasses import dataclass
+import math
+import os
+from typing import Any
+
+import torch
+from torch.nn.attention import SDPBackend, sdpa_kernel
+import torch.nn as nn
+import torch.nn.functional as F
+
+from phyai.layers.attention import Attention
+from phyai.layers.layer_norm import LayerNorm as PhyAILayerNorm
+from phyai.layers.linear.layers import ReplicatedLinear
+from phyai.models.gr00t_n17.configuration_gr00t_n17 import (
+    GR00TN17Config,
+    GR00TN17DiTConfig,
+    GR00TN17VLSelfAttentionConfig,
+)
+from phyai.utils import load_config
+from phyai.weights.shards import replicated
+
+
+_DIT_SDPA_MATH_ENV = "PHYAI_GR00T_DIT_SDPA_MATH"
+_STATIC_CATEGORY_IDS: ContextVar[tuple[int, ...] | None] = ContextVar(
+    "_STATIC_CATEGORY_IDS",
+    default=None,
+)
+
+
+@contextmanager
+def gr00t_n17_static_category_ids(category_ids: tuple[int, ...] | None):
+    """Specialize embodiment-conditioned linears for fixed CUDA graphs."""
+    token = _STATIC_CATEGORY_IDS.set(category_ids)
+    try:
+        yield
+    finally:
+        _STATIC_CATEGORY_IDS.reset(token)
+
+
+def _dit_math_sdpa_context():
+    """SDPA backend context for the action-head DiT ``"sdpa"`` attention.
+
+    Default: a no-op context, so SDPA uses PyTorch's normal dispatch (flash for
+    the unmasked self-attn, mem-efficient for the masked cross-attn on A40);
+    end-to-end action parity vs the reference is ~0.0221.
+
+    Set ``PHYAI_GR00T_DIT_SDPA_MATH`` truthy to force the **math** SDPA backend
+    instead — mirroring the official Isaac-GR00T DiT, which forces math via
+    ``sdp_kernel(enable_flash=False)`` / ``GR00T_DIT_SDPA_MODE=math`` — for
+    tighter parity (~0.0190). Both paths are CUDA-graph captureable (the backend
+    is baked in at capture). Neither is byte-exact: ``"eager"`` does the softmax
+    in fp32 and is the only 0.0166 path (kept for debug).
+    """
+    if os.environ.get(_DIT_SDPA_MATH_ENV, "").strip().lower() in {
+        "1",
+        "on",
+        "true",
+        "yes",
+    }:
+        return sdpa_kernel([SDPBackend.MATH])
+    return nullcontext()
+
+
+# ============================================================================ #
+# 1. Shared primitives / PhyAI wrappers                                         #
+# ============================================================================ #
+
+
+def _resolve_backbone_config_dir(
+    model_name_or_path: str, *, local_files_only: bool = False
+) -> str:
+    """Return a local directory holding the backbone ``config.json``.
+
+    A local directory is used as-is. Otherwise the path is treated as a
+    HuggingFace repo id and resolved against the local hub cache via
+    ``huggingface_hub`` (no ``transformers`` model machinery). With
+    ``local_files_only`` the cached snapshot is used without any network
+    access.
+    """
+    from pathlib import Path
+
+    candidate = Path(model_name_or_path)
+    if candidate.is_dir():
+        return str(candidate)
+
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(
+        model_name_or_path,
+        allow_patterns=["config.json"],
+        local_files_only=local_files_only,
+    )
+
+
+class GR00TN17NativeImplementationError(NotImplementedError):
+    """Raised when a GR00T-N1.7 native submodule has not been ported yet."""
+
+
+@dataclass(frozen=True)
+class GR00TN17BackboneOutput:
+    """Backbone output consumed by the action head."""
+
+    backbone_features: torch.Tensor
+    backbone_attention_mask: torch.Tensor
+    image_mask: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class GR00TN17ActionInput:
+    """Action-head inputs after preprocessing."""
+
+    state: torch.Tensor
+    embodiment_id: torch.Tensor
+    action_mask: torch.Tensor | None = None
+    action: torch.Tensor | None = None
+
+
+class GR00TN17Identity(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+class GR00TN17Dropout(nn.Module):
+    def __init__(self, p: float = 0.0) -> None:
+        super().__init__()
+        self.p = float(p)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.p == 0.0 or not self.training:
+            return x
+        keep_prob = 1.0 - self.p
+        mask = torch.empty_like(x).bernoulli_(keep_prob)
+        return x * mask / keep_prob
+
+
+class GR00TN17LayerNorm(PhyAILayerNorm):
+    def __init__(
+        self,
+        normalized_shape: int,
+        *,
+        eps: float = 1e-5,
+        elementwise_affine: bool = True,
+    ) -> None:
+        if elementwise_affine:
+            super().__init__(
+                int(normalized_shape),
+                eps=eps,
+                backend="phyai-kernel",
+                bias=True,
+                prefix="",
+            )
+            self.elementwise_affine = True
+            return
+
+        nn.Module.__init__(self)
+        self.elementwise_affine = False
+        self.backend = "phyai-kernel"
+        self.hidden_size = int(normalized_shape)
+        self.variance_epsilon = float(eps)
+        self.has_bias = False
+        self.prefix = ""
+        self.register_buffer("weight", torch.ones(self.hidden_size), persistent=False)
+        self.register_buffer("_zero_beta", None, persistent=False)
+        self._layernorm = None
+
+    @staticmethod
+    def _torch_layer_norm(
+        x: torch.Tensor,
+        weight: torch.Tensor | None,
+        bias: torch.Tensor | None,
+        eps: float,
+    ) -> torch.Tensor:
+        x_float = x.float()
+        mean = x_float.mean(dim=-1, keepdim=True)
+        var = (x_float - mean).square().mean(dim=-1, keepdim=True)
+        out = (x_float - mean) * torch.rsqrt(var + eps)
+        out = out.to(dtype=x.dtype)
+        if weight is not None:
+            out = out * weight.to(device=x.device, dtype=x.dtype)
+        if bias is not None:
+            out = out + bias.to(device=x.device, dtype=x.dtype)
+        return out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not x.is_cuda:
+            weight = self.weight if self.elementwise_affine else None
+            bias = self.bias if self.elementwise_affine else None
+            return self._torch_layer_norm(x, weight, bias, self.variance_epsilon)
+
+        if self.elementwise_affine:
+            return super().forward(x)
+
+        if self._layernorm is None:
+            from phyai_kernel import layernorm
+
+            self._layernorm = layernorm
+        needs_reshape = x.dim() != 2
+        if needs_reshape:
+            orig_shape = x.shape
+            x = x.contiguous().reshape(-1, orig_shape[-1])
+        out = self._layernorm(
+            x,
+            self.weight.to(device=x.device, dtype=torch.float32),
+            None,
+            self.variance_epsilon,
+        )
+        if needs_reshape:
+            out = out.reshape(orig_shape)
+        return out
+
+
+class GR00TN17ReplicatedEmbedding(nn.Module):
+    def __init__(self, num_embeddings: int, embedding_dim: int) -> None:
+        super().__init__()
+        self.num_embeddings = int(num_embeddings)
+        self.embedding_dim = int(embedding_dim)
+        self.weight = nn.Parameter(torch.empty(self.num_embeddings, self.embedding_dim))
+        self.weight.hf_keys = []
+        self.weight.weight_loader = replicated()
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.weight[input_ids]
+
+
+# ============================================================================ #
+# 2. Qwen3-VL backbone boundary                                                 #
+# ============================================================================ #
+
+
+class GR00TN17Backbone(nn.Module):
+    """Qwen3-VL / Cosmos-Reason2 backbone boundary."""
+
+    def __init__(
+        self,
+        config: GR00TN17Config,
+        *,
+        qwen3vl_model: nn.Module | None = None,
+        params_dtype: torch.dtype | None = None,
+        device: torch.device | str | None = None,
+        transformers_loading_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config.backbone
+        self.qwen3vl_model = qwen3vl_model
+        self.params_dtype = params_dtype
+        self.target_device = torch.device(device) if device is not None else None
+        self.transformers_loading_kwargs = dict(transformers_loading_kwargs or {})
+
+    def prepare_input(self, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        return dict(batch)
+
+    def _truncate_language_layers(self, qwen3vl_model: nn.Module) -> None:
+        if self.config.select_layer < 0:
+            return
+        language_model = getattr(qwen3vl_model, "language_model", None)
+        if language_model is None:
+            nested_model = getattr(qwen3vl_model, "model", None)
+            language_model = getattr(nested_model, "language_model", None)
+        layers = getattr(language_model, "layers", None)
+        if layers is None:
+            return
+        while len(layers) > self.config.select_layer:
+            layers.pop(-1)
+
+    def _attach_qwen3vl_weight_keys(self, qwen3vl_model: nn.Module) -> None:
+        for name, param in qwen3vl_model.named_parameters():
+            _attach_replicated_hf_key(param, f"backbone.model.{name}")
+
+    def _load_qwen3vl_model(self) -> nn.Module:
+        if not self.config.use_native_qwen3vl:
+            raise RuntimeError(
+                "GR00T-N1.7 no longer supports the Transformers Qwen3VL model "
+                "fallback. Set use_native_qwen3vl=True and use the PhyAI native "
+                "backbone."
+            )
+        if self.qwen3vl_model is not None:
+            self._truncate_language_layers(self.qwen3vl_model)
+            self._attach_qwen3vl_weight_keys(self.qwen3vl_model)
+            return self.qwen3vl_model
+
+        from phyai.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig
+        from phyai.models.gr00t_n17.qwen3_vl_native import (
+            GR00TN17NativeQwen3VLForConditionalGeneration,
+        )
+
+        qwen3vl_config = self.config.qwen3vl
+        if qwen3vl_config is None:
+            backbone_dir = _resolve_backbone_config_dir(
+                self.config.model_name,
+                local_files_only=self.transformers_loading_kwargs.get(
+                    "local_files_only", False
+                ),
+            )
+            qwen3vl_config = load_config(backbone_dir, Qwen3VLConfig)
+        dtype = (
+            torch.bfloat16
+            if self.config.load_bf16
+            else self.params_dtype or torch.get_default_dtype()
+        )
+        self.qwen3vl_model = GR00TN17NativeQwen3VLForConditionalGeneration(
+            qwen3vl_config,
+            select_layer=self.config.select_layer,
+            params_dtype=dtype,
+            device=self.target_device,
+            attention_backend=self.config.attention_backend,
+        ).eval()
+        return self.qwen3vl_model
+
+    def prepare_position_ids(
+        self, batch: dict[str, torch.Tensor]
+    ) -> torch.Tensor | None:
+        vl_input = self.prepare_input(batch)
+        required_keys = ("input_ids", "attention_mask", "image_grid_thw")
+        missing = [key for key in required_keys if key not in vl_input]
+        if missing:
+            raise KeyError(f"backbone position-id inputs missing keys: {missing}")
+        qwen3vl_model = self._load_qwen3vl_model()
+        native_model = getattr(qwen3vl_model, "model", None)
+        if native_model is None or not hasattr(native_model, "get_rope_index"):
+            return None
+        input_ids = vl_input["input_ids"]
+        mm_token_type_ids = vl_input.get("mm_token_type_ids")
+        if mm_token_type_ids is None:
+            image_token_id = qwen3vl_model.config.image_token_id
+            mm_token_type_ids = torch.zeros_like(input_ids, dtype=torch.int32)
+            mm_token_type_ids = mm_token_type_ids.masked_fill(
+                input_ids == image_token_id, 1
+            )
+        position_ids, _ = native_model.get_rope_index(
+            input_ids,
+            mm_token_type_ids,
+            image_grid_thw=vl_input["image_grid_thw"],
+            attention_mask=vl_input["attention_mask"],
+        )
+        return position_ids
+
+    def _ensure_qwen3vl_model_device(self, device: torch.device) -> None:
+        qwen3vl_model = self._load_qwen3vl_model()
+        try:
+            current_device = next(iter(qwen3vl_model.parameters())).device
+        except StopIteration:
+            return
+        if current_device == device:
+            return
+        if self.config.load_bf16:
+            qwen3vl_model.to(device=device, dtype=torch.bfloat16)
+        else:
+            qwen3vl_model.to(device=device)
+
+    def _prepare_model_inputs(
+        self, inputs: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        vl_input = self.prepare_input(inputs)
+        required_keys = ("input_ids", "attention_mask", "pixel_values", "image_grid_thw")
+        optional_keys = (
+            "mm_token_type_ids",
+            "position_ids",
+            "pixel_values_videos",
+            "video_grid_thw",
+            "second_per_grid_ts",
+        )
+        missing = [key for key in required_keys if key not in vl_input]
+        if missing:
+            raise KeyError(f"backbone inputs missing keys: {missing}")
+        model_inputs = {key: vl_input[key] for key in required_keys}
+        model_inputs.update({key: vl_input[key] for key in optional_keys if key in vl_input})
+        self._ensure_qwen3vl_model_device(model_inputs["input_ids"].device)
+        return model_inputs
+
+    def _build_output(
+        self,
+        backbone_features: torch.Tensor,
+        model_inputs: dict[str, torch.Tensor],
+    ) -> GR00TN17BackboneOutput:
+        image_token_id = self._load_qwen3vl_model().config.image_token_id
+        return GR00TN17BackboneOutput(
+            backbone_features=backbone_features,
+            backbone_attention_mask=model_inputs["attention_mask"] == 1,
+            image_mask=model_inputs["input_ids"] == image_token_id,
+        )
+
+    def backbone_graph_plan(self, inputs: dict[str, torch.Tensor]):
+        """Runner-facing host-sync preamble for the single backbone CUDA graph.
+
+        Returns ``(core_fn, buffers, key, model_inputs)`` for the **runner** to
+        capture/replay, or ``None`` when the input is not graph-eligible (the
+        runner then falls back to the eager :meth:`forward`). The capture itself
+        lives in the runner, so the backbone modeling holds no graph state.
+        """
+        model_inputs = self._prepare_model_inputs(inputs)
+        plan = self._load_qwen3vl_model().model.backbone_graph_plan(
+            **model_inputs,
+            graph_seq_len_buckets=self.config.graph_seq_len_buckets,
+        )
+        if plan is None:
+            return None
+        core_fn, buffers, key, graph_model_inputs = plan
+        return core_fn, buffers, key, graph_model_inputs
+
+    def build_graph_output(
+        self,
+        backbone_features: torch.Tensor,
+        model_inputs: dict[str, torch.Tensor],
+    ) -> GR00TN17BackboneOutput:
+        """Wrap a captured-core ``pre_norm_hidden_state`` into a backbone output."""
+        return self._build_output(backbone_features, model_inputs)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> GR00TN17BackboneOutput:
+        model_inputs = self._prepare_model_inputs(inputs)
+        outputs = self._load_qwen3vl_model()(**model_inputs)
+        # Pre-final-norm features, returned directly by the text model so the
+        # value is valid under CUDA-graph replay (a forward_pre_hook would not
+        # re-fire). Falls back to the last hidden state for any model variant
+        # that does not expose it.
+        backbone_features = getattr(outputs, "pre_norm_hidden_state", None)
+        if backbone_features is None:
+            backbone_features = outputs.hidden_states[-1]
+        return self._build_output(backbone_features, model_inputs)
+
+
+# ============================================================================ #
+# 6. Action head: encoders + DiT + decoder                                      #
+# ============================================================================ #
+
+
+def _swish(x: torch.Tensor) -> torch.Tensor:
+    return x * torch.sigmoid(x)
+
+
+def _gelu_tanh(x: torch.Tensor) -> torch.Tensor:
+    return 0.5 * x * (
+        1.0
+        + torch.tanh(
+            math.sqrt(2.0 / math.pi) * (x + 0.044715 * torch.pow(x, 3))
+        )
+    )
+
+
+def _pad_last_dim(x: torch.Tensor, pad_right: int) -> torch.Tensor:
+    if pad_right == 0:
+        return x
+    pad_shape = (*x.shape[:-1], pad_right)
+    return torch.cat((x, x.new_zeros(pad_shape)), dim=-1)
+
+
+def _calculate_fan_in_and_fan_out(tensor: torch.Tensor) -> tuple[int, int]:
+    if tensor.dim() < 2:
+        raise ValueError("fan in and fan out require a tensor with at least 2 dims.")
+    num_input_fmaps = tensor.size(1)
+    num_output_fmaps = tensor.size(0)
+    receptive_field_size = 1
+    if tensor.dim() > 2:
+        for size in tensor.shape[2:]:
+            receptive_field_size *= size
+    return (
+        num_input_fmaps * receptive_field_size,
+        num_output_fmaps * receptive_field_size,
+    )
+
+
+def _init_kaiming_uniform_(tensor: torch.Tensor, a: float) -> None:
+    fan_in, _ = _calculate_fan_in_and_fan_out(tensor)
+    gain = math.sqrt(2.0 / (1.0 + a**2))
+    std = gain / math.sqrt(fan_in)
+    bound = math.sqrt(3.0) * std
+    with torch.no_grad():
+        tensor.uniform_(-bound, bound)
+
+
+def _init_uniform_(tensor: torch.Tensor, low: float, high: float) -> None:
+    with torch.no_grad():
+        tensor.uniform_(low, high)
+
+
+def _init_normal_(tensor: torch.Tensor, mean: float, std: float) -> None:
+    with torch.no_grad():
+        tensor.normal_(mean=mean, std=std)
+
+
+def _init_zeros_(tensor: torch.Tensor) -> None:
+    with torch.no_grad():
+        tensor.zero_()
+
+
+def _attach_replicated_hf_key(param: nn.Parameter, hf_key: str) -> None:
+    param.hf_keys = [(hf_key, None)]
+    param.weight_loader = replicated()
+
+
+def _is_cuda_graph_capturing(x: torch.Tensor) -> bool:
+    if not x.is_cuda:
+        return False
+    try:
+        return bool(torch.cuda.is_current_stream_capturing())
+    except RuntimeError:
+        return False
+
+
+def _replicated_linear(linear: ReplicatedLinear, x: torch.Tensor) -> torch.Tensor:
+    out, bias = ReplicatedLinear.forward(linear, x)
+    if bias is not None:
+        return out + bias
+    return out
+
+
+class GR00TN17Linear(ReplicatedLinear):
+    """Replicated PhyAI linear with the same tensor-return API as Linear."""
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True) -> None:
+        super().__init__(in_features, out_features, bias=bias, prefix="")
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        _init_kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is None:
+            return
+        fan_in, _ = _calculate_fan_in_and_fan_out(self.weight)
+        bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+        _init_uniform_(self.bias, -bound, bound)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _replicated_linear(self, x)
+
+
+def _gr00t_n17_action_head_hf_key(local_name: str, prefix: str) -> str:
+    """Map native module parameter names to Isaac-GR00T checkpoint keys."""
+    hf_name = local_name
+    if hf_name.startswith("model.timestep_encoder."):
+        hf_name = hf_name.replace(
+            "model.timestep_encoder.linear_",
+            "model.timestep_encoder.timestep_embedder.linear_",
+            1,
+        )
+    hf_name = hf_name.replace(".attn1.to_out.", ".attn1.to_out.0.")
+    hf_name = hf_name.replace(".ff.fc1.", ".ff.net.0.proj.")
+    hf_name = hf_name.replace(".ff.fc2.", ".ff.net.2.")
+    return f"{prefix}.{hf_name}" if prefix else hf_name
+
+
+def _timestep_embedding(
+    timesteps: torch.Tensor,
+    dim: int,
+    *,
+    max_period: int = 10000,
+    downscale_freq_shift: float = 1.0,
+    flip_sin_to_cos: bool = True,
+) -> torch.Tensor:
+    """Diffusers-style sinusoidal timestep features."""
+    half = dim // 2
+    exponent = -math.log(max_period) * torch.arange(
+        half, device=timesteps.device, dtype=torch.float32
+    )
+    exponent = exponent / (half - downscale_freq_shift)
+    args = timesteps.float()[:, None] * torch.exp(exponent)[None]
+    emb = torch.cat((torch.sin(args), torch.cos(args)), dim=-1)
+    if flip_sin_to_cos:
+        emb = torch.cat((emb[:, half:], emb[:, :half]), dim=-1)
+    if dim % 2 == 1:
+        emb = _pad_last_dim(emb, 1)
+    return emb
+
+
+class GR00TN17SinusoidalPositionalEncoding(nn.Module):
+    """Sinusoidal encoding for action timesteps."""
+
+    def __init__(self, embedding_dim: int) -> None:
+        super().__init__()
+        self.embedding_dim = int(embedding_dim)
+
+    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
+        if timesteps.ndim != 2:
+            raise ValueError(
+                "timesteps must have shape (batch, sequence), got "
+                f"{tuple(timesteps.shape)}."
+            )
+        half_dim = self.embedding_dim // 2
+        exponent = -torch.arange(
+            half_dim, dtype=torch.float32, device=timesteps.device
+        )
+        exponent = exponent * (math.log(10000.0) / half_dim)
+        freqs = timesteps.float().unsqueeze(-1) * exponent.exp()
+        enc = torch.cat((torch.sin(freqs), torch.cos(freqs)), dim=-1)
+        if self.embedding_dim % 2 == 1:
+            enc = _pad_last_dim(enc, 1)
+        return enc
+
+
+class GR00TN17CategorySpecificLinear(nn.Module):
+    """Linear layer with independent weights per embodiment id."""
+
+    def __init__(self, num_categories: int, input_dim: int, output_dim: int) -> None:
+        super().__init__()
+        self.num_categories = int(num_categories)
+        self.input_dim = int(input_dim)
+        self.output_dim = int(output_dim)
+        self.linears = nn.ModuleList(
+            [
+                ReplicatedLinear(
+                    self.input_dim,
+                    self.output_dim,
+                    bias=True,
+                    prefix="",
+                )
+                for _ in range(self.num_categories)
+            ]
+        )
+        for linear in self.linears:
+            _init_normal_(linear.weight, mean=0.0, std=0.02)
+            if linear.bias is not None:
+                _init_zeros_(linear.bias)
+
+    def attach_hf_keys(self, prefix: str) -> None:
+        """Load official stacked W/b tensors into per-embodiment linears."""
+
+        def _load_weight(_param: nn.Parameter, tensor: torch.Tensor, _shard_id: object) -> None:
+            if tuple(tensor.shape) != (
+                self.num_categories,
+                self.input_dim,
+                self.output_dim,
+            ):
+                raise ValueError(
+                    f"{prefix}.W shape mismatch: expected "
+                    f"{(self.num_categories, self.input_dim, self.output_dim)}, "
+                    f"got {tuple(tensor.shape)}."
+                )
+            for cat_id, linear in enumerate(self.linears):
+                linear.weight.data.copy_(
+                    tensor[cat_id].T.to(
+                        device=linear.weight.device,
+                        dtype=linear.weight.dtype,
+                    )
+                )
+
+        def _load_bias(_param: nn.Parameter, tensor: torch.Tensor, _shard_id: object) -> None:
+            if tuple(tensor.shape) != (self.num_categories, self.output_dim):
+                raise ValueError(
+                    f"{prefix}.b shape mismatch: expected "
+                    f"{(self.num_categories, self.output_dim)}, got {tuple(tensor.shape)}."
+                )
+            for cat_id, linear in enumerate(self.linears):
+                if linear.bias is None:
+                    continue
+                linear.bias.data.copy_(
+                    tensor[cat_id].to(
+                        device=linear.bias.device,
+                        dtype=linear.bias.dtype,
+                    )
+                )
+
+        first = self.linears[0]
+        first.weight.hf_keys = [(f"{prefix}.W", None)]
+        first.weight.weight_loader = _load_weight
+        if first.bias is not None:
+            first.bias.hf_keys = [(f"{prefix}.b", None)]
+            first.bias.weight_loader = _load_bias
+
+    def forward(self, x: torch.Tensor, cat_ids: torch.Tensor) -> torch.Tensor:
+        if x.ndim != 3:
+            raise ValueError(f"x must have shape (B, T, C), got {tuple(x.shape)}.")
+        if cat_ids.ndim != 1 or cat_ids.shape[0] != x.shape[0]:
+            raise ValueError(
+                "cat_ids must have shape (B,), got "
+                f"{tuple(cat_ids.shape)} for batch {x.shape[0]}."
+            )
+        static_cat_ids = _STATIC_CATEGORY_IDS.get()
+        if static_cat_ids is not None:
+            if len(static_cat_ids) != x.shape[0]:
+                raise ValueError(
+                    "static category id count must match batch size: "
+                    f"{len(static_cat_ids)} vs {x.shape[0]}."
+                )
+            if any(
+                cat_id < 0 or cat_id >= self.num_categories
+                for cat_id in static_cat_ids
+            ):
+                raise ValueError(
+                    f"static category ids must be in [0, {self.num_categories})."
+                )
+            first_cat = static_cat_ids[0]
+            if all(cat_id == first_cat for cat_id in static_cat_ids):
+                return _replicated_linear(self.linears[first_cat], x)
+            outs = [
+                _replicated_linear(self.linears[cat_id], x[row : row + 1])
+                for row, cat_id in enumerate(static_cat_ids)
+            ]
+            return torch.cat(outs, dim=0)
+        if _is_cuda_graph_capturing(x):
+            out = x.new_zeros(x.shape[0], x.shape[1], self.output_dim)
+            cat_ids = cat_ids.long()
+            for cat_id, linear in enumerate(self.linears):
+                cat_out = _replicated_linear(linear, x)
+                mask = (cat_ids == cat_id).to(dtype=cat_out.dtype)[:, None, None]
+                out = out + cat_out * mask
+            return out
+        out = x.new_empty(x.shape[0], x.shape[1], self.output_dim)
+        cat_ids = cat_ids.long()
+        for cat_id, linear in enumerate(self.linears):
+            indices = torch.nonzero(cat_ids == cat_id, as_tuple=False).flatten()
+            if indices.numel() == 0:
+                continue
+            cat_x = x.index_select(0, indices)
+            cat_out = _replicated_linear(linear, cat_x)
+            out.index_copy_(0, indices, cat_out)
+        return out
+
+
+class GR00TN17CategorySpecificMLP(nn.Module):
+    """Two-layer embodiment-conditioned MLP."""
+
+    def __init__(
+        self,
+        num_categories: int,
+        input_dim: int,
+        hidden_dim: int,
+        output_dim: int,
+    ) -> None:
+        super().__init__()
+        self.layer1 = GR00TN17CategorySpecificLinear(
+            num_categories, input_dim, hidden_dim
+        )
+        self.layer2 = GR00TN17CategorySpecificLinear(
+            num_categories, hidden_dim, output_dim
+        )
+
+    def forward(self, x: torch.Tensor, cat_ids: torch.Tensor) -> torch.Tensor:
+        return self.layer2(torch.relu(self.layer1(x, cat_ids)), cat_ids)
+
+
+class GR00TN17MultiEmbodimentActionEncoder(nn.Module):
+    """Action encoder with embodiment-specific projections and time features."""
+
+    def __init__(self, action_dim: int, hidden_size: int, num_embodiments: int) -> None:
+        super().__init__()
+        self.hidden_size = int(hidden_size)
+        self.W1 = GR00TN17CategorySpecificLinear(
+            num_embodiments, action_dim, hidden_size
+        )
+        self.W2 = GR00TN17CategorySpecificLinear(
+            num_embodiments, 2 * hidden_size, hidden_size
+        )
+        self.W3 = GR00TN17CategorySpecificLinear(
+            num_embodiments, hidden_size, hidden_size
+        )
+        self.pos_encoding = GR00TN17SinusoidalPositionalEncoding(hidden_size)
+
+    def forward(
+        self,
+        actions: torch.Tensor,
+        timesteps: torch.Tensor,
+        cat_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if actions.ndim != 3:
+            raise ValueError(
+                f"actions must have shape (B, T, C), got {tuple(actions.shape)}."
+            )
+        batch, horizon, _ = actions.shape
+        if timesteps.ndim != 1 or timesteps.shape[0] != batch:
+            raise ValueError(
+                "timesteps must have shape (B,), got "
+                f"{tuple(timesteps.shape)} for batch {batch}."
+            )
+        a_emb = self.W1(actions, cat_ids)
+        tau = timesteps[:, None].expand(batch, horizon)
+        tau_emb = self.pos_encoding(tau).to(dtype=a_emb.dtype)
+        x = torch.cat((a_emb, tau_emb), dim=-1)
+        x = _swish(self.W2(x, cat_ids))
+        return self.W3(x, cat_ids)
+
+
+class GR00TN17TimestepEncoder(nn.Module):
+    """Sinusoidal timestep projection followed by a two-layer MLP."""
+
+    def __init__(self, embedding_dim: int) -> None:
+        super().__init__()
+        self.linear_1 = GR00TN17Linear(256, embedding_dim)
+        self.linear_2 = GR00TN17Linear(embedding_dim, embedding_dim)
+
+    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
+        dtype = self.linear_1.weight.dtype
+        emb = _timestep_embedding(timesteps, 256).to(dtype=dtype)
+        return self.linear_2(_swish(self.linear_1(emb)))
+
+
+class GR00TN17AdaLayerNorm(nn.Module):
+    """Adaptive LayerNorm conditioned on timestep embeddings."""
+
+    def __init__(self, embedding_dim: int, norm_eps: float = 1e-5) -> None:
+        super().__init__()
+        self.linear = GR00TN17Linear(embedding_dim, 2 * embedding_dim)
+        self.norm = GR00TN17LayerNorm(
+            embedding_dim, eps=norm_eps, elementwise_affine=False
+        )
+
+    def forward(self, x: torch.Tensor, temb: torch.Tensor) -> torch.Tensor:
+        scale, shift = self.linear(_swish(temb)).chunk(2, dim=1)
+        return self.norm(x) * (1 + scale[:, None]) + shift[:, None]
+
+
+class GR00TN17Attention(nn.Module):
+    """Small backend-selectable attention module for DiT self/cross attention.
+
+    The default backend is ``"sdpa"`` (phyai's recommended path, CUDA-graph
+    captureable). ``"eager"`` is an opt-in fp32-softmax path reached **only** when
+    that backend is selected explicitly; it is kept solely because it is the
+    tightest match to the Isaac-GR00T reference numerics (parity validation).
+    ``"flashinfer"`` covers the unmasked self-attention path and falls back to the
+    ``"sdpa"`` masked path for cross-attention (GR00T's cross-attention uses
+    key-only masks, which flashinfer's prefill kernel does not take).
+    """
+
+    _SUPPORTED_BACKENDS = frozenset({"eager", "sdpa", "flashinfer"})
+
+    def __init__(
+        self,
+        query_dim: int,
+        *,
+        num_heads: int,
+        head_dim: int,
+        cross_attention_dim: int | None = None,
+        dropout: float = 0.0,
+        bias: bool = True,
+        backend: str = "sdpa",
+    ) -> None:
+        super().__init__()
+        self.num_heads = int(num_heads)
+        self.head_dim = int(head_dim)
+        self.inner_dim = self.num_heads * self.head_dim
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.attention_backend = str(backend).lower().replace("_", "-")
+        if self.attention_backend not in self._SUPPORTED_BACKENDS:
+            supported = ", ".join(sorted(self._SUPPORTED_BACKENDS))
+            raise ValueError(
+                f"GR00TN17Attention backend must be one of: {supported}; "
+                f"got {backend!r}."
+            )
+        kv_dim = int(cross_attention_dim or query_dim)
+        self.to_q = GR00TN17Linear(query_dim, self.inner_dim, bias=bias)
+        self.to_k = GR00TN17Linear(kv_dim, self.inner_dim, bias=bias)
+        self.to_v = GR00TN17Linear(kv_dim, self.inner_dim, bias=bias)
+        self.to_out = GR00TN17Linear(self.inner_dim, query_dim, bias=True)
+        self.dropout = float(dropout)
+        backend_kwargs = {"compile": False} if self.attention_backend == "sdpa" else None
+        self.prefill_attention = Attention(
+            self.num_heads,
+            self.head_dim,
+            causal=False,
+            backend=self.attention_backend,
+            backend_kwargs=backend_kwargs,
+        )
+
+    @staticmethod
+    def _expand_key_mask(
+        attention_mask: torch.Tensor | None,
+        *,
+        device: torch.device,
+    ) -> torch.Tensor | None:
+        if attention_mask is None:
+            return None
+        attn_mask = attention_mask.to(device=device, dtype=torch.bool)
+        return attn_mask[:, None, None, :]
+
+    def _eager_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        scores = torch.matmul(q, k.transpose(-2, -1)) * self.scale
+        if attention_mask is not None:
+            scores = scores.masked_fill(
+                ~attention_mask, torch.finfo(scores.dtype).min
+            )
+        attn = torch.softmax(scores.float(), dim=-1).to(dtype=q.dtype)
+        if attention_mask is not None:
+            attn = attn * attention_mask.to(dtype=attn.dtype)
+        if self.dropout > 0.0 and self.training:
+            keep_prob = 1.0 - self.dropout
+            attn = attn * torch.empty_like(attn).bernoulli_(keep_prob) / keep_prob
+        return torch.matmul(attn, v)
+
+    def _sdpa_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        dropout_p = self.dropout if self.training else 0.0
+        return F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=attention_mask,
+            dropout_p=dropout_p,
+            is_causal=False,
+            scale=self.scale,
+        )
+
+    def _backend_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        encoder_hidden_states: torch.Tensor | None,
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        use_prefill = (
+            encoder_hidden_states is None
+            and attention_mask is None
+            and (not self.training or self.dropout == 0.0)
+            and (self.attention_backend != "flashinfer" or q.is_cuda)
+        )
+        # The "sdpa" backend runs under a forced-math SDPA context (mirroring the
+        # official DiT) so both the self-attn (prefill) and masked cross-attn
+        # paths match the reference numerics; other backends use no context.
+        ctx = (
+            _dit_math_sdpa_context()
+            if self.attention_backend == "sdpa"
+            else nullcontext()
+        )
+        with ctx:
+            if use_prefill:
+                return self.prefill_attention(
+                    q.transpose(1, 2),
+                    k.transpose(1, 2),
+                    v.transpose(1, 2),
+                ).transpose(1, 2)
+            if self.attention_backend == "eager":
+                return self._eager_attention(q, k, v, attention_mask=attention_mask)
+            # "sdpa" and the "flashinfer" masked cross-attn fallback both land
+            # here: flashinfer's prefill kernel only covers the unmasked
+            # self-attention path, so its masked cross-attention falls back to
+            # SDPA rather than the fp32 eager path (which is reserved for the
+            # explicit "eager" parity-validation backend).
+            return self._sdpa_attention(q, k, v, attention_mask=attention_mask)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        encoder_hidden_states: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        encoder_kv: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        key_value_states = (
+            hidden_states if encoder_hidden_states is None else encoder_hidden_states
+        )
+        batch, target_len, _ = hidden_states.shape
+
+        q = self.to_q(hidden_states)
+        q = q.view(batch, target_len, self.num_heads, self.head_dim)
+        q = q.transpose(1, 2)
+        if encoder_kv is None:
+            k, v = self.project_kv(key_value_states)
+        else:
+            k, v = encoder_kv
+        attn_mask = self._expand_key_mask(attention_mask, device=hidden_states.device)
+        out = self._backend_attention(
+            q,
+            k,
+            v,
+            encoder_hidden_states=encoder_hidden_states,
+            attention_mask=attn_mask,
+        )
+        out = out.transpose(1, 2).contiguous().view(batch, target_len, self.inner_dim)
+        return self.to_out(out)
+
+    def project_kv(
+        self, key_value_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch, source_len, _ = key_value_states.shape
+        k = self.to_k(key_value_states)
+        v = self.to_v(key_value_states)
+        k = k.view(batch, source_len, self.num_heads, self.head_dim)
+        v = v.view(batch, source_len, self.num_heads, self.head_dim)
+        return k.transpose(1, 2), v.transpose(1, 2)
+
+
+class GR00TN17FeedForward(nn.Module):
+    """DiT feed-forward block."""
+
+    def __init__(self, dim: int, *, dropout: float, final_dropout: bool) -> None:
+        super().__init__()
+        self.fc1 = GR00TN17Linear(dim, 4 * dim)
+        self.fc2 = GR00TN17Linear(4 * dim, dim)
+        self.dropout = GR00TN17Dropout(dropout)
+        self.final_dropout = (
+            GR00TN17Dropout(dropout) if final_dropout else GR00TN17Identity()
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = _gelu_tanh(self.fc1(x))
+        x = self.dropout(x)
+        x = self.fc2(x)
+        return self.final_dropout(x)
+
+
+class GR00TN17BasicTransformerBlock(nn.Module):
+    """DiT transformer block matching the GR00T action-head topology."""
+
+    def __init__(
+        self,
+        dim: int,
+        config: GR00TN17DiTConfig,
+        *,
+        cross_attention_dim: int | None,
+    ) -> None:
+        super().__init__()
+        self.norm_type = config.norm_type
+        self.is_cross_attention = cross_attention_dim is not None
+        if config.norm_type == "ada_norm":
+            self.norm1 = GR00TN17AdaLayerNorm(dim)
+        else:
+            self.norm1 = GR00TN17LayerNorm(
+                dim, eps=1e-5, elementwise_affine=config.norm_elementwise_affine
+            )
+        self.attn1 = GR00TN17Attention(
+            dim,
+            num_heads=config.num_attention_heads,
+            head_dim=config.attention_head_dim,
+            cross_attention_dim=cross_attention_dim,
+            dropout=config.dropout,
+            bias=True,
+            backend=config.attention_backend,
+        )
+        self.norm3 = GR00TN17LayerNorm(
+            dim, eps=1e-5, elementwise_affine=config.norm_elementwise_affine
+        )
+        self.ff = GR00TN17FeedForward(
+            dim, dropout=config.dropout, final_dropout=config.final_dropout
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        encoder_hidden_states: torch.Tensor | None = None,
+        encoder_attention_mask: torch.Tensor | None = None,
+        encoder_kv: tuple[torch.Tensor, torch.Tensor] | None = None,
+        temb: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.norm_type == "ada_norm":
+            norm_hidden_states = self.norm1(hidden_states, temb)
+        else:
+            norm_hidden_states = self.norm1(hidden_states)
+        attn_output = self.attn1(
+            norm_hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            attention_mask=encoder_attention_mask,
+            encoder_kv=encoder_kv,
+        )
+        hidden_states = hidden_states + attn_output
+        return hidden_states + self.ff(self.norm3(hidden_states))
+
+
+class GR00TN17DiT(nn.Module):
+    """Native diffusion transformer used by the GR00T-N1.7 action head."""
+
+    def __init__(
+        self,
+        config: GR00TN17DiTConfig,
+        *,
+        cross_attention_dim: int,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.inner_dim = config.num_attention_heads * config.attention_head_dim
+        self.output_dim = config.output_dim
+        self.timestep_encoder = GR00TN17TimestepEncoder(self.inner_dim)
+        blocks = []
+        for idx in range(config.num_layers):
+            use_self_attn = idx % 2 == 1 and config.interleave_self_attention
+            blocks.append(
+                GR00TN17BasicTransformerBlock(
+                    self.inner_dim,
+                    config,
+                    cross_attention_dim=None
+                    if use_self_attn
+                    else cross_attention_dim,
+                )
+            )
+        self.transformer_blocks = nn.ModuleList(blocks)
+        self.norm_out = GR00TN17LayerNorm(
+            self.inner_dim, eps=1e-6, elementwise_affine=False
+        )
+        self.proj_out_1 = GR00TN17Linear(self.inner_dim, 2 * self.inner_dim)
+        self.proj_out_2 = GR00TN17Linear(self.inner_dim, self.output_dim)
+
+    def precompute_encoder_kv(
+        self,
+        encoder_hidden_states: torch.Tensor,
+    ) -> list[tuple[torch.Tensor, torch.Tensor] | None]:
+        """Project fixed cross-attention K/V once per action inference."""
+        cache: list[tuple[torch.Tensor, torch.Tensor] | None] = []
+        for block in self.transformer_blocks:
+            if block.is_cross_attention:
+                cache.append(block.attn1.project_kv(encoder_hidden_states))
+            else:
+                cache.append(None)
+        return cache
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        *,
+        timestep: torch.Tensor,
+        encoder_attention_mask: torch.Tensor | None = None,
+        encoder_kv_cache: list[tuple[torch.Tensor, torch.Tensor] | None] | None = None,
+        return_all_hidden_states: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
+        if hidden_states.shape[-1] != self.inner_dim:
+            raise ValueError(
+                "hidden_states last dim must match DiT inner_dim "
+                f"{self.inner_dim}, got {hidden_states.shape[-1]}."
+            )
+        temb = self.timestep_encoder(timestep)
+        all_hidden_states = [hidden_states]
+        for idx, block in enumerate(self.transformer_blocks):
+            encoder_kv = encoder_kv_cache[idx] if encoder_kv_cache is not None else None
+            if idx % 2 == 1 and self.config.interleave_self_attention:
+                hidden_states = block(
+                    hidden_states,
+                    encoder_hidden_states=None,
+                    encoder_attention_mask=None,
+                    temb=temb,
+                )
+            else:
+                hidden_states = block(
+                    hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_attention_mask=encoder_attention_mask,
+                    encoder_kv=encoder_kv,
+                    temb=temb,
+                )
+            all_hidden_states.append(hidden_states)
+
+        shift, scale = self.proj_out_1(_swish(temb)).chunk(2, dim=1)
+        hidden_states = self.norm_out(hidden_states) * (1 + scale[:, None]) + shift[
+            :, None
+        ]
+        output = self.proj_out_2(hidden_states)
+        if return_all_hidden_states:
+            return output, all_hidden_states
+        return output
+
+
+class GR00TN17AlternateVLDiT(GR00TN17DiT):
+    """DiT variant alternating text-token and image-token cross attention."""
+
+    def __init__(
+        self,
+        config: GR00TN17DiTConfig,
+        *,
+        cross_attention_dim: int,
+        attend_text_every_n_blocks: int,
+    ) -> None:
+        super().__init__(config, cross_attention_dim=cross_attention_dim)
+        self.attend_text_every_n_blocks = int(attend_text_every_n_blocks)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        *,
+        timestep: torch.Tensor,
+        encoder_attention_mask: torch.Tensor | None = None,
+        encoder_kv_cache: list[tuple[torch.Tensor, torch.Tensor] | None] | None = None,
+        return_all_hidden_states: bool = False,
+        image_mask: torch.Tensor | None = None,
+        backbone_attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
+        if image_mask is None:
+            raise ValueError("image_mask is required when use_alternate_vl_dit=True.")
+        if backbone_attention_mask is None:
+            if encoder_attention_mask is None:
+                backbone_attention_mask = torch.ones_like(image_mask, dtype=torch.bool)
+            else:
+                backbone_attention_mask = encoder_attention_mask
+
+        temb = self.timestep_encoder(timestep)
+        image_attention_mask = image_mask.bool() & backbone_attention_mask.bool()
+        non_image_attention_mask = (~image_mask.bool()) & backbone_attention_mask.bool()
+        all_hidden_states = [hidden_states]
+        for idx, block in enumerate(self.transformer_blocks):
+            encoder_kv = encoder_kv_cache[idx] if encoder_kv_cache is not None else None
+            if idx % 2 == 1:
+                hidden_states = block(
+                    hidden_states,
+                    encoder_hidden_states=None,
+                    encoder_attention_mask=None,
+                    temb=temb,
+                )
+            else:
+                if idx % (2 * self.attend_text_every_n_blocks) == 0:
+                    curr_mask = non_image_attention_mask
+                else:
+                    curr_mask = image_attention_mask
+                hidden_states = block(
+                    hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_attention_mask=curr_mask,
+                    encoder_kv=encoder_kv,
+                    temb=temb,
+                )
+            all_hidden_states.append(hidden_states)
+
+        shift, scale = self.proj_out_1(_swish(temb)).chunk(2, dim=1)
+        hidden_states = self.norm_out(hidden_states) * (1 + scale[:, None]) + shift[
+            :, None
+        ]
+        output = self.proj_out_2(hidden_states)
+        if return_all_hidden_states:
+            return output, all_hidden_states
+        return output
+
+
+class GR00TN17SelfAttentionTransformer(nn.Module):
+    """Optional VL self-attention stack before action cross-attention."""
+
+    def __init__(self, config: GR00TN17VLSelfAttentionConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.inner_dim = config.num_attention_heads * config.attention_head_dim
+        if config.positional_embeddings is not None:
+            raise GR00TN17NativeImplementationError(
+                "GR00T-N1.7 VL self-attention positional embeddings are not "
+                "implemented yet."
+            )
+        self.transformer_blocks = nn.ModuleList(
+            [
+                GR00TN17SelfAttentionBlock(
+                    self.inner_dim,
+                    num_heads=config.num_attention_heads,
+                    head_dim=config.attention_head_dim,
+                    dropout=config.dropout,
+                    final_dropout=config.final_dropout,
+                    attention_backend=config.attention_backend,
+                )
+                for _ in range(config.num_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        for block in self.transformer_blocks:
+            hidden_states = block(hidden_states, attention_mask=attention_mask)
+        return hidden_states
+
+
+class GR00TN17SelfAttentionBlock(nn.Module):
+    """LayerNorm + self-attention + FFN block used by VL self-attention."""
+
+    def __init__(
+        self,
+        dim: int,
+        *,
+        num_heads: int,
+        head_dim: int,
+        dropout: float,
+        final_dropout: bool,
+        attention_backend: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = GR00TN17LayerNorm(dim, eps=1e-5, elementwise_affine=True)
+        self.attn1 = GR00TN17Attention(
+            dim,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            cross_attention_dim=None,
+            dropout=dropout,
+            bias=True,
+            backend=attention_backend,
+        )
+        self.norm3 = GR00TN17LayerNorm(dim, eps=1e-5, elementwise_affine=True)
+        self.ff = GR00TN17FeedForward(
+            dim, dropout=dropout, final_dropout=final_dropout
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn1(
+            self.norm1(hidden_states),
+            attention_mask=attention_mask,
+        )
+        return hidden_states + self.ff(self.norm3(hidden_states))
+
+
+class GR00TN17ActionHead(nn.Module):
+    """Flow-matching action head boundary."""
+
+    def __init__(self, config: GR00TN17Config) -> None:
+        super().__init__()
+        self.config = config.action_head
+        self.backbone_config = config.backbone
+        self.hidden_size = int(self.config.hidden_size)
+        self.input_embedding_dim = int(self.config.input_embedding_dim)
+        self.action_dim = int(self.config.max_action_dim)
+        self.action_horizon = int(self.config.action_horizon)
+        self.num_inference_timesteps = int(self.config.num_inference_timesteps)
+        self.num_timestep_buckets = int(self.config.num_timestep_buckets)
+        dit_inner_dim = (
+            self.config.dit.num_attention_heads * self.config.dit.attention_head_dim
+        )
+        if dit_inner_dim != self.input_embedding_dim:
+            raise ValueError(
+                "action_head.input_embedding_dim must equal "
+                "dit.num_attention_heads * dit.attention_head_dim "
+                f"({dit_inner_dim}), got {self.input_embedding_dim}."
+            )
+
+        if self.config.use_alternate_vl_dit:
+            self.model = GR00TN17AlternateVLDiT(
+                self.config.dit,
+                cross_attention_dim=self.backbone_config.backbone_embedding_dim,
+                attend_text_every_n_blocks=self.config.attend_text_every_n_blocks,
+            )
+        else:
+            self.model = GR00TN17DiT(
+                self.config.dit,
+                cross_attention_dim=self.backbone_config.backbone_embedding_dim,
+            )
+        self.state_encoder = GR00TN17CategorySpecificMLP(
+            num_categories=self.config.max_num_embodiments,
+            input_dim=self.config.max_state_dim * self.config.state_history_length,
+            hidden_dim=self.hidden_size,
+            output_dim=self.input_embedding_dim,
+        )
+        self.action_encoder = GR00TN17MultiEmbodimentActionEncoder(
+            action_dim=self.action_dim,
+            hidden_size=self.input_embedding_dim,
+            num_embodiments=self.config.max_num_embodiments,
+        )
+        self.action_decoder = GR00TN17CategorySpecificMLP(
+            num_categories=self.config.max_num_embodiments,
+            input_dim=self.hidden_size,
+            hidden_dim=self.hidden_size,
+            output_dim=self.action_dim,
+        )
+        self.vlln = (
+            GR00TN17LayerNorm(self.backbone_config.backbone_embedding_dim)
+            if self.config.use_vlln
+            else GR00TN17Identity()
+        )
+        if (
+            self.config.vl_self_attention is not None
+            and self.config.vl_self_attention.num_layers > 0
+        ):
+            self.vl_self_attention = GR00TN17SelfAttentionTransformer(
+                self.config.vl_self_attention
+            )
+        else:
+            self.vl_self_attention = GR00TN17Identity()
+        if self.config.add_pos_embed:
+            self.position_embedding = GR00TN17ReplicatedEmbedding(
+                self.config.max_seq_len, self.input_embedding_dim
+            )
+            _init_normal_(self.position_embedding.weight, mean=0.0, std=0.02)
+
+    def attach_hf_keys(self, prefix: str = "action_head") -> None:
+        """Attach Isaac-GR00T safetensors keys to every action-head parameter."""
+        category_param_ids: set[int] = set()
+        for local_name, module in self.named_modules():
+            if isinstance(module, GR00TN17CategorySpecificLinear):
+                module.attach_hf_keys(_gr00t_n17_action_head_hf_key(local_name, prefix))
+                category_param_ids.update(id(param) for param in module.parameters())
+        for local_name, param in self.named_parameters():
+            if id(param) in category_param_ids:
+                continue
+            _attach_replicated_hf_key(
+                param, _gr00t_n17_action_head_hf_key(local_name, prefix)
+            )
+
+    def process_backbone_output(
+        self, backbone_output: GR00TN17BackboneOutput
+    ) -> GR00TN17BackboneOutput:
+        backbone_features = self.vlln(backbone_output.backbone_features)
+        if isinstance(self.vl_self_attention, GR00TN17SelfAttentionTransformer):
+            backbone_features = self.vl_self_attention(
+                backbone_features,
+                attention_mask=backbone_output.backbone_attention_mask,
+            )
+        else:
+            backbone_features = self.vl_self_attention(backbone_features)
+        return GR00TN17BackboneOutput(
+            backbone_features=backbone_features,
+            backbone_attention_mask=backbone_output.backbone_attention_mask,
+            image_mask=backbone_output.image_mask,
+        )
+
+    def _encode_features(
+        self,
+        backbone_output: GR00TN17BackboneOutput,
+        action_input: GR00TN17ActionInput,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        backbone_output = self.process_backbone_output(backbone_output)
+        state = action_input.state
+        if state.ndim != 3:
+            raise ValueError(
+                "state must have shape (B, state_history_length, max_state_dim), "
+                f"got {tuple(state.shape)}."
+            )
+        if state.shape[1] != self.config.state_history_length:
+            raise ValueError(
+                "state history length mismatch: expected "
+                f"{self.config.state_history_length}, got {state.shape[1]}."
+            )
+        state = state.reshape(state.shape[0], 1, -1)
+        state_features = self.state_encoder(state, action_input.embodiment_id)
+        return backbone_output.backbone_features, state_features
+
+    def _positioned_action_features(self, action_features: torch.Tensor) -> torch.Tensor:
+        if not self.config.add_pos_embed:
+            return action_features
+        if action_features.shape[1] > self.config.max_seq_len:
+            raise ValueError(
+                "action horizon exceeds max_seq_len for position embedding: "
+                f"{action_features.shape[1]} > {self.config.max_seq_len}."
+            )
+        pos_ids = torch.arange(
+            action_features.shape[1], dtype=torch.long, device=action_features.device
+        )
+        return action_features + self.position_embedding(pos_ids).unsqueeze(0)
+
+    def get_action_with_features(
+        self,
+        *,
+        backbone_features: torch.Tensor,
+        state_features: torch.Tensor,
+        embodiment_id: torch.Tensor,
+        backbone_output: GR00TN17BackboneOutput,
+        action_input: GR00TN17ActionInput,
+        noise: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        actions = self.prepare_initial_actions(backbone_features, noise=noise)
+        encoder_kv_cache = self.precompute_dit_encoder_kv(backbone_features)
+        for step in range(self.num_inference_timesteps):
+            actions = self.denoise_step(
+                actions,
+                step,
+                backbone_features=backbone_features,
+                state_features=state_features,
+                embodiment_id=embodiment_id,
+                backbone_output=backbone_output,
+                action_input=action_input,
+                encoder_kv_cache=encoder_kv_cache,
+            )
+        return actions
+
+    def precompute_dit_encoder_kv(
+        self,
+        backbone_features: torch.Tensor,
+    ) -> list[tuple[torch.Tensor, torch.Tensor] | None]:
+        return self.model.precompute_encoder_kv(backbone_features)
+
+    def prepare_initial_actions(
+        self,
+        backbone_features: torch.Tensor,
+        *,
+        noise: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        batch_size = backbone_features.shape[0]
+        device = backbone_features.device
+        if noise is None:
+            return torch.randn(
+                batch_size,
+                self.action_horizon,
+                self.action_dim,
+                dtype=backbone_features.dtype,
+                device=device,
+            )
+        else:
+            expected = (batch_size, self.action_horizon, self.action_dim)
+            if tuple(noise.shape) != expected:
+                raise ValueError(
+                    f"noise must have shape {expected}, got {tuple(noise.shape)}."
+                )
+            return noise.to(device=device, dtype=backbone_features.dtype)
+
+    def denoise_step(
+        self,
+        actions: torch.Tensor,
+        step: int,
+        *,
+        backbone_features: torch.Tensor,
+        state_features: torch.Tensor,
+        embodiment_id: torch.Tensor,
+        backbone_output: GR00TN17BackboneOutput,
+        action_input: GR00TN17ActionInput,
+        encoder_kv_cache: list[tuple[torch.Tensor, torch.Tensor] | None] | None = None,
+    ) -> torch.Tensor:
+        dt = 1.0 / self.num_inference_timesteps
+        vel_strength = torch.ones_like(actions)
+        if action_input.action is not None:
+            raise GR00TN17NativeImplementationError(
+                "RTC/inpainting action inputs are not implemented in the native "
+                "GR00T-N1.7 action-head path yet."
+            )
+
+        batch_size = actions.shape[0]
+        device = actions.device
+        t_cont = step / float(self.num_inference_timesteps)
+        t_discretized = int(t_cont * self.num_timestep_buckets)
+        timesteps = torch.full(
+            (batch_size,), t_discretized, dtype=torch.long, device=device
+        )
+        action_features = self.action_encoder(actions, timesteps, embodiment_id)
+        action_features = self._positioned_action_features(action_features)
+        sa_embs = torch.cat((state_features, action_features), dim=1)
+        if self.config.use_alternate_vl_dit:
+            image_mask = backbone_output.image_mask
+            if image_mask is None:
+                image_mask = torch.zeros(
+                    backbone_output.backbone_attention_mask.shape,
+                    dtype=torch.bool,
+                    device=device,
+                )
+            model_output = self.model(
+                sa_embs,
+                backbone_features,
+                timestep=timesteps,
+                encoder_kv_cache=encoder_kv_cache,
+                image_mask=image_mask,
+                backbone_attention_mask=backbone_output.backbone_attention_mask,
+            )
+        else:
+            model_output = self.model(
+                sa_embs,
+                backbone_features,
+                timestep=timesteps,
+                encoder_attention_mask=backbone_output.backbone_attention_mask,
+                encoder_kv_cache=encoder_kv_cache,
+            )
+        pred = self.action_decoder(model_output, embodiment_id)
+        pred_velocity = pred[:, -self.action_horizon :]
+        return actions + dt * pred_velocity * vel_strength
+
+    def get_action(
+        self,
+        backbone_output: GR00TN17BackboneOutput,
+        action_input: GR00TN17ActionInput,
+        *,
+        noise: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        backbone_features, state_features = self._encode_features(
+            backbone_output, action_input
+        )
+        return self.get_action_with_features(
+            backbone_features=backbone_features,
+            state_features=state_features,
+            embodiment_id=action_input.embodiment_id,
+            backbone_output=backbone_output,
+            action_input=action_input,
+            noise=noise,
+        )
+
+
+# ============================================================================ #
+# 7. Top-level GR00TN17Model                                                    #
+# ============================================================================ #
+
+
+class GR00TN17Model(nn.Module):
+    """GR00T-N1.7 parameter container.
+
+    This class does not own scheduler state and does
+    not expose a monolithic ``forward``. Runners will call the backbone
+    and action-head pieces independently once their native
+    implementations land.
+    """
+
+    def __init__(
+        self,
+        config: GR00TN17Config,
+        *,
+        params_dtype: torch.dtype | None = None,
+        device: torch.device | str | None = None,
+        backbone_qwen3vl_model: nn.Module | None = None,
+        backbone_transformers_loading_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.params_dtype = params_dtype or torch.get_default_dtype()
+        self.backbone = GR00TN17Backbone(
+            config,
+            qwen3vl_model=backbone_qwen3vl_model,
+            params_dtype=self.params_dtype,
+            device=device,
+            transformers_loading_kwargs=backbone_transformers_loading_kwargs,
+        )
+        self.action_head = GR00TN17ActionHead(config)
+        self.action_head.attach_hf_keys("action_head")
+        if device is not None or params_dtype is not None:
+            self.to(device=device, dtype=self.params_dtype)
+
+    def prepare_backbone_input(
+        self, inputs: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        return self.backbone.prepare_input(inputs)
+
+    def prepare_action_input(
+        self, inputs: dict[str, torch.Tensor]
+    ) -> GR00TN17ActionInput:
+        batch = dict(inputs)
+        required = ("state", "embodiment_id")
+        missing = [key for key in required if key not in batch]
+        if missing:
+            raise KeyError(f"action inputs missing keys: {missing}")
+        return GR00TN17ActionInput(
+            state=batch["state"],
+            embodiment_id=batch["embodiment_id"],
+            action_mask=batch.get("action_mask"),
+            action=batch.get("action"),
+        )
+
+    def prepare_input(
+        self,
+        inputs: dict[str, torch.Tensor],
+        *,
+        device: torch.device | str | None = None,
+    ) -> tuple[dict[str, torch.Tensor], GR00TN17ActionInput]:
+        target_device = torch.device(device) if device is not None else self.device
+
+        def move(value: torch.Tensor) -> torch.Tensor:
+            if torch.is_floating_point(value):
+                return value.to(device=target_device, dtype=self.dtype)
+            return value.to(device=target_device)
+
+        moved = {
+            key: move(value) if isinstance(value, torch.Tensor) else value
+            for key, value in dict(inputs).items()
+        }
+        return self.prepare_backbone_input(moved), self.prepare_action_input(moved)
+
+    def get_action(
+        self,
+        inputs: dict[str, torch.Tensor],
+        *,
+        noise: torch.Tensor | None = None,
+        device: torch.device | str | None = None,
+    ) -> torch.Tensor:
+        backbone_inputs, action_inputs = self.prepare_input(inputs, device=device)
+        backbone_output = self.backbone(backbone_inputs)
+        return self.action_head.get_action(backbone_output, action_inputs, noise=noise)
+
+    @property
+    def device(self) -> torch.device:
+        return next(iter(self.parameters())).device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(iter(self.parameters())).dtype
+
+
+__all__ = [
+    "GR00TN17ActionHead",
+    "GR00TN17ActionInput",
+    "GR00TN17Backbone",
+    "GR00TN17BackboneOutput",
+    "GR00TN17Model",
+    "GR00TN17NativeImplementationError",
+]

--- a/phyai/src/phyai/models/gr00t_n17/qwen3_vl_native.py
+++ b/phyai/src/phyai/models/gr00t_n17/qwen3_vl_native.py
@@ -148,9 +148,9 @@ class GR00TN17QwenRMSNorm(nn.Module):
         hidden_states = hidden_states.float()
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
         hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-        return self.weight.to(device=hidden_states.device, dtype=input_dtype) * hidden_states.to(
-            input_dtype
-        )
+        return self.weight.to(
+            device=hidden_states.device, dtype=input_dtype
+        ) * hidden_states.to(input_dtype)
 
 
 class GR00TN17QwenLayerNorm(nn.Module):
@@ -199,7 +199,9 @@ class GR00TN17QwenEmbedding(nn.Module):
     ) -> None:
         super().__init__()
         self.weight = nn.Parameter(
-            torch.empty(num_embeddings, embedding_dim, dtype=params_dtype, device=device),
+            torch.empty(
+                num_embeddings, embedding_dim, dtype=params_dtype, device=device
+            ),
             requires_grad=False,
         )
         _attach_replicated_hf_key(self.weight, f"{prefix}.weight")
@@ -267,18 +269,20 @@ class GR00TN17QwenVisionRotaryEmbedding(nn.Module):
         super().__init__()
         self.dim = int(dim)
         self.theta = float(theta)
-        inv_freq = 1.0 / (
-            theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
-        )
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
     def forward(self, seqlen: int) -> torch.Tensor:
-        seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+        seq = torch.arange(
+            seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
+        )
         return torch.outer(seq, self.inv_freq)
 
 
 class GR00TN17QwenVisionMLP(nn.Module):
-    def __init__(self, config: Any, *, prefix: str, params_dtype=None, device=None) -> None:
+    def __init__(
+        self, config: Any, *, prefix: str, params_dtype=None, device=None
+    ) -> None:
         super().__init__()
         self.linear_fc1 = GR00TN17QwenLinear(
             config.hidden_size,
@@ -408,9 +412,7 @@ class GR00TN17QwenVisionAttention(nn.Module):
         seq_length = hidden_states.shape[0]
         qkv = self.qkv(hidden_states)
         query_states, key_states, value_states = (
-            qkv.reshape(seq_length, 3, self.num_heads, -1)
-            .permute(1, 0, 2, 3)
-            .unbind(0)
+            qkv.reshape(seq_length, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
         )
         cos, sin = position_embeddings
         query_states, key_states = _apply_rotary_pos_emb_vision(
@@ -444,13 +446,17 @@ class GR00TN17QwenVisionAttention(nn.Module):
             ]
             out = torch.cat(outs, dim=1).reshape(seq_length, -1).contiguous()
         else:
-            out = self.attn(
-                query_states,
-                key_states,
-                value_states,
-                cu_seqlens_q=cu_seqlens,
-                cu_seqlens_kv=cu_seqlens,
-            ).reshape(seq_length, -1).contiguous()
+            out = (
+                self.attn(
+                    query_states,
+                    key_states,
+                    value_states,
+                    cu_seqlens_q=cu_seqlens,
+                    cu_seqlens_kv=cu_seqlens,
+                )
+                .reshape(seq_length, -1)
+                .contiguous()
+            )
         return self.proj(out)
 
 
@@ -643,7 +649,9 @@ class GR00TN17QwenVisionModel(nn.Module):
         for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
             pos_embed = pos_embed.repeat(t, 1)
             pos_embed = (
-                pos_embed.view(t, h // merge_size, merge_size, w // merge_size, merge_size, -1)
+                pos_embed.view(
+                    t, h // merge_size, merge_size, w // merge_size, merge_size, -1
+                )
                 .permute(0, 1, 3, 2, 4, 5)
                 .flatten(0, 4)
             )
@@ -734,16 +742,19 @@ class GR00TN17QwenTextRotaryEmbedding(nn.Module):
     def __init__(self, config: Any) -> None:
         super().__init__()
         base = config.rope_theta
-        dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
-        inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
+        dim = (
+            getattr(config, "head_dim", None)
+            or config.hidden_size // config.num_attention_heads
         )
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.attention_scaling = 1.0
         self.mrope_section = list(config.mrope_section)
 
     @staticmethod
-    def apply_interleaved_mrope(freqs: torch.Tensor, mrope_section: list[int]) -> torch.Tensor:
+    def apply_interleaved_mrope(
+        freqs: torch.Tensor, mrope_section: list[int]
+    ) -> torch.Tensor:
         freqs_t = freqs[0].clone()
         for dim, offset in enumerate((1, 2), start=1):
             length = mrope_section[dim] * 3
@@ -751,12 +762,16 @@ class GR00TN17QwenTextRotaryEmbedding(nn.Module):
             freqs_t[..., idx] = freqs[dim, ..., idx]
         return freqs_t
 
-    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
         inv_freq = self.inv_freq.to(device=x.device)
-        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(
-            3, position_ids.shape[1], -1, 1
+        inv_freq_expanded = (
+            inv_freq[None, None, :, None]
+            .float()
+            .expand(3, position_ids.shape[1], -1, 1)
         )
         position_ids_expanded = position_ids[:, :, None, :].float()
         freqs = (inv_freq_expanded @ position_ids_expanded).transpose(2, 3)
@@ -765,7 +780,9 @@ class GR00TN17QwenTextRotaryEmbedding(nn.Module):
         return emb.cos().to(dtype=x.dtype), emb.sin().to(dtype=x.dtype)
 
 
-def _apply_text_rotary(q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+def _apply_text_rotary(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
     cos = cos.unsqueeze(1)
     sin = sin.unsqueeze(1)
     q_embed = (q * cos) + (rotate_half(q) * sin)
@@ -786,7 +803,9 @@ class GR00TN17QwenTextAttention(nn.Module):
     ) -> None:
         super().__init__()
         self.layer_idx = int(layer_idx)
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_heads = int(config.num_attention_heads)
         self.num_key_value_heads = int(config.num_key_value_heads)
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
@@ -863,9 +882,8 @@ class GR00TN17QwenTextAttention(nn.Module):
         v = self.v_proj(hidden_states).view(kv_shape).transpose(1, 2)
         cos, sin = position_embeddings
         q, k = _apply_text_rotary(q, k, cos, sin)
-        if (
-            attention_mask is None
-            and (self.attention_backend != "flashinfer" or q.is_cuda)
+        if attention_mask is None and (
+            self.attention_backend != "flashinfer" or q.is_cuda
         ):
             out = self.attn(
                 q.transpose(1, 2),
@@ -887,7 +905,9 @@ class GR00TN17QwenTextAttention(nn.Module):
 
 
 class GR00TN17QwenTextMLP(nn.Module):
-    def __init__(self, config: Any, *, prefix: str, params_dtype=None, device=None) -> None:
+    def __init__(
+        self, config: Any, *, prefix: str, params_dtype=None, device=None
+    ) -> None:
         super().__init__()
         self.gate_proj = GR00TN17QwenLinear(
             config.hidden_size,
@@ -1045,10 +1065,19 @@ class GR00TN17QwenTextModel(nn.Module):
         else:
             causal = text_position_ids[:, None, :] > text_position_ids[:, :, None]
             causal = causal[:, None, :, :].to(device=inputs_embeds.device)
-        mask = torch.zeros(batch, 1, seq_len, seq_len, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
+        mask = torch.zeros(
+            batch,
+            1,
+            seq_len,
+            seq_len,
+            dtype=inputs_embeds.dtype,
+            device=inputs_embeds.device,
+        )
         mask = mask.masked_fill(causal, min_dtype)
         if attention_mask is not None:
-            key_padding = attention_mask[:, None, None, :].to(device=inputs_embeds.device).bool()
+            key_padding = (
+                attention_mask[:, None, None, :].to(device=inputs_embeds.device).bool()
+            )
             mask = mask.masked_fill(~key_padding, min_dtype)
         return mask
 
@@ -1147,7 +1176,9 @@ class GR00TN17QwenTextModel(nn.Module):
             rope_position_ids = position_ids
         else:
             text_position_ids = position_ids
-            rope_position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+            rope_position_ids = position_ids[None, ...].expand(
+                3, position_ids.shape[0], -1
+            )
         attention_mask_4d = self._causal_mask(
             inputs_embeds, attention_mask, text_position_ids
         )
@@ -1237,9 +1268,12 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
         position_width = torch.arange(llm_grid_w, device=device) + start_position
         position_height = torch.arange(llm_grid_h, device=device) + start_position
         position_width = position_width.repeat(llm_grid_h * llm_grid_t)
-        position_height = position_height.repeat_interleave(llm_grid_w).repeat(llm_grid_t)
+        position_height = position_height.repeat_interleave(llm_grid_w).repeat(
+            llm_grid_t
+        )
         position_temporal = (
-            position_temporal.repeat_interleave(llm_grid_h * llm_grid_w) + start_position
+            position_temporal.repeat_interleave(llm_grid_h * llm_grid_w)
+            + start_position
         )
         return torch.stack([position_temporal, position_height, position_width], dim=0)
 
@@ -1252,7 +1286,9 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
         attention_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if video_grid_thw is not None:
-            video_grid_thw = torch.repeat_interleave(video_grid_thw, video_grid_thw[:, 0], dim=0)
+            video_grid_thw = torch.repeat_interleave(
+                video_grid_thw, video_grid_thw[:, 0], dim=0
+            )
             video_grid_thw[:, 0] = 1
         spatial_merge_size = self.config.vision.spatial_merge_size
         position_ids = torch.zeros(
@@ -1273,7 +1309,9 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
                 current_input_ids = current_input_ids[attention_mask[batch_idx].bool()]
                 input_type = input_type[attention_mask[batch_idx].bool()]
             groups = []
-            for key, group in itertools.groupby(enumerate(input_type.tolist()), lambda x: x[1]):
+            for key, group in itertools.groupby(
+                enumerate(input_type.tolist()), lambda x: x[1]
+            ):
                 group = list(group)
                 groups.append((key, group[0][0], group[-1][0] + 1))
             current_pos = 0
@@ -1301,11 +1339,17 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
                     current_pos += max(grid_thw[1], grid_thw[2]) // spatial_merge_size
             llm_positions = torch.cat(pos_list, dim=1).reshape(3, -1)
             if attention_mask is not None:
-                position_ids[:, batch_idx, attention_mask[batch_idx].bool()] = llm_positions
+                position_ids[:, batch_idx, attention_mask[batch_idx].bool()] = (
+                    llm_positions
+                )
             else:
                 position_ids[:, batch_idx] = llm_positions
-            mrope_position_deltas.append(llm_positions.max() + 1 - len(current_input_ids))
-        return position_ids, torch.tensor(mrope_position_deltas, device=input_ids.device).unsqueeze(1)
+            mrope_position_deltas.append(
+                llm_positions.max() + 1 - len(current_input_ids)
+            )
+        return position_ids, torch.tensor(
+            mrope_position_deltas, device=input_ids.device
+        ).unsqueeze(1)
 
     def get_image_features(
         self,
@@ -1315,8 +1359,12 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
         vision_output = self.visual(
             pixel_values.type(self.visual.dtype), grid_thw=image_grid_thw
         )
-        split_sizes = (image_grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
-        vision_output.pooler_output = torch.split(vision_output.pooler_output, split_sizes)
+        split_sizes = (
+            image_grid_thw.prod(-1) // self.visual.spatial_merge_size**2
+        ).tolist()
+        vision_output.pooler_output = torch.split(
+            vision_output.pooler_output, split_sizes
+        )
         return vision_output
 
     def get_placeholder_mask(
@@ -1401,7 +1449,9 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
             attention_mask = torch.ones_like(input_ids, dtype=torch.long)
         if mm_token_type_ids is None:
             mm_token_type_ids = torch.zeros_like(input_ids, dtype=torch.int32)
-            mm_token_type_ids = mm_token_type_ids.masked_fill(input_ids == self.config.image_token_id, 1)
+            mm_token_type_ids = mm_token_type_ids.masked_fill(
+                input_ids == self.config.image_token_id, 1
+            )
         seq_len = int(input_ids.shape[1])
         if graph_seq_len_buckets is not None:
             bucket = next((b for b in graph_seq_len_buckets if seq_len <= b), None)
@@ -1421,10 +1471,7 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
                 image_grid_thw=image_grid_thw,
                 attention_mask=attention_mask,
             )
-        if not (
-            position_ids.ndim == 3
-            and position_ids.shape[0] == 3
-        ):
+        if not (position_ids.ndim == 3 and position_ids.shape[0] == 3):
             return None
         pixel_values = pixel_values.type(self.visual.dtype)
         device = pixel_values.device
@@ -1512,7 +1559,9 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
         :meth:`backbone_graph_plan`; this module holds no graph state."""
         if mm_token_type_ids is None:
             mm_token_type_ids = torch.zeros_like(input_ids, dtype=torch.int32)
-            mm_token_type_ids = mm_token_type_ids.masked_fill(input_ids == self.config.image_token_id, 1)
+            mm_token_type_ids = mm_token_type_ids.masked_fill(
+                input_ids == self.config.image_token_id, 1
+            )
         if position_ids is None:
             position_ids, _ = self.get_rope_index(
                 input_ids,

--- a/phyai/src/phyai/models/gr00t_n17/qwen3_vl_native.py
+++ b/phyai/src/phyai/models/gr00t_n17/qwen3_vl_native.py
@@ -1,0 +1,1583 @@
+"""Native Qwen3-VL pieces used by GR00T-N1.7.
+
+This file is an inference-focused port of the Qwen3-VL model structure
+from Hugging Face Transformers' Apache-2.0 implementation:
+``transformers.models.qwen3_vl.modeling_qwen3_vl``.
+
+Scope for this first native pass:
+* GR00T prefill/image path, no generation logits needed by the scheduler.
+* No KV cache path.
+* Image inputs are supported; video hooks are intentionally left out until
+  GR00T needs them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import itertools
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from phyai.layers.attention import Attention
+from phyai.layers.linear.layers import ReplicatedLinear
+from phyai.layers.rotary_embedding import rotate_half
+from phyai.models.qwen3_vl.modeling_qwen3_vl import (
+    get_vision_cu_seqlens,
+    get_vision_position_ids,
+)
+from phyai.weights.shards import replicated
+
+
+# NOTE: the Qwen3-VL backbone is stateless. CUDA-graph capture/replay for the
+# ViT and LLM cores is owned by ``GR00TN17BackboneRunner`` (model_runner), which
+# passes a graph context into ``forward``; when it is ``None`` the eager path
+# runs (byte-identical to the reference).
+
+
+# ============================================================================ #
+#  Qwen3-VL native common layers                                              #
+# ============================================================================ #
+
+
+def _attach_replicated_hf_key(param: nn.Parameter, hf_key: str) -> None:
+    param.hf_keys = [(hf_key, None)]
+    param.weight_loader = replicated()
+
+
+def _replicated_linear(linear: ReplicatedLinear, x: torch.Tensor) -> torch.Tensor:
+    out, bias = ReplicatedLinear.forward(linear, x)
+    if bias is not None:
+        return out + bias
+    return out
+
+
+def _gelu_tanh(x: torch.Tensor) -> torch.Tensor:
+    return F.gelu(x, approximate="tanh")
+
+
+def _silu(x: torch.Tensor) -> torch.Tensor:
+    return x * torch.sigmoid(x)
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def _attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    attention_mask: torch.Tensor | None,
+    scaling: float,
+    num_key_value_groups: int = 1,
+    is_causal: bool = False,
+) -> torch.Tensor:
+    key = _repeat_kv(key, num_key_value_groups)
+    value = _repeat_kv(value, num_key_value_groups)
+    out = F.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=attention_mask,
+        dropout_p=0.0,
+        is_causal=is_causal,
+        scale=scaling,
+    )
+    return out.transpose(1, 2).contiguous()
+
+
+def _attention_backend_kwargs(backend: str) -> dict[str, Any] | None:
+    return {"compile": False} if backend == "sdpa" else None
+
+
+class GR00TN17QwenLinear(ReplicatedLinear):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        bias: bool,
+        prefix: str,
+        params_dtype: torch.dtype | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        super().__init__(
+            in_features,
+            out_features,
+            bias=bias,
+            prefix=prefix,
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _replicated_linear(self, x)
+
+
+class GR00TN17QwenRMSNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        *,
+        eps: float,
+        prefix: str,
+        params_dtype: torch.dtype | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        super().__init__()
+        self.variance_epsilon = float(eps)
+        self.weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=params_dtype, device=device),
+            requires_grad=False,
+        )
+        _attach_replicated_hf_key(self.weight, f"{prefix}.weight")
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.float()
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight.to(device=hidden_states.device, dtype=input_dtype) * hidden_states.to(
+            input_dtype
+        )
+
+
+class GR00TN17QwenLayerNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        *,
+        eps: float,
+        prefix: str,
+        params_dtype: torch.dtype | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = int(hidden_size)
+        self.variance_epsilon = float(eps)
+        self.weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=params_dtype, device=device),
+            requires_grad=False,
+        )
+        self.bias = nn.Parameter(
+            torch.zeros(hidden_size, dtype=params_dtype, device=device),
+            requires_grad=False,
+        )
+        _attach_replicated_hf_key(self.weight, f"{prefix}.weight")
+        _attach_replicated_hf_key(self.bias, f"{prefix}.bias")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.layer_norm(
+            x,
+            (self.hidden_size,),
+            self.weight.to(device=x.device),
+            self.bias.to(device=x.device),
+            self.variance_epsilon,
+        )
+
+
+class GR00TN17QwenEmbedding(nn.Module):
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        *,
+        prefix: str,
+        params_dtype: torch.dtype | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.empty(num_embeddings, embedding_dim, dtype=params_dtype, device=device),
+            requires_grad=False,
+        )
+        _attach_replicated_hf_key(self.weight, f"{prefix}.weight")
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.weight[input_ids]
+
+
+class GR00TN17QwenConv3dPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        prefix: str,
+        params_dtype: torch.dtype | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        super().__init__()
+        self.patch_size = int(config.patch_size)
+        self.temporal_patch_size = int(config.temporal_patch_size)
+        self.in_channels = int(config.in_channels)
+        self.embed_dim = int(config.hidden_size)
+        kernel = (self.temporal_patch_size, self.patch_size, self.patch_size)
+        self.weight = nn.Parameter(
+            torch.empty(
+                self.embed_dim,
+                self.in_channels,
+                *kernel,
+                dtype=params_dtype,
+                device=device,
+            ),
+            requires_grad=False,
+        )
+        self.bias = nn.Parameter(
+            torch.empty(self.embed_dim, dtype=params_dtype, device=device),
+            requires_grad=False,
+        )
+        _attach_replicated_hf_key(self.weight, f"{prefix}.weight")
+        _attach_replicated_hf_key(self.bias, f"{prefix}.bias")
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = hidden_states.view(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        hidden_states = F.conv3d(
+            hidden_states.to(dtype=self.weight.dtype),
+            self.weight,
+            self.bias,
+            stride=(self.temporal_patch_size, self.patch_size, self.patch_size),
+        )
+        return hidden_states.view(-1, self.embed_dim)
+
+
+# ============================================================================ #
+# Qwen3-VL vision tower                                                      #
+# ============================================================================ #
+
+
+class GR00TN17QwenVisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = int(dim)
+        self.theta = float(theta)
+        inv_freq = 1.0 / (
+            theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+        return torch.outer(seq, self.inv_freq)
+
+
+class GR00TN17QwenVisionMLP(nn.Module):
+    def __init__(self, config: Any, *, prefix: str, params_dtype=None, device=None) -> None:
+        super().__init__()
+        self.linear_fc1 = GR00TN17QwenLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=True,
+            prefix=f"{prefix}.linear_fc1",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.linear_fc2 = GR00TN17QwenLinear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=True,
+            prefix=f"{prefix}.linear_fc2",
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        return self.linear_fc2(_gelu_tanh(self.linear_fc1(hidden_state)))
+
+
+class GR00TN17QwenVisionPatchMerger(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        prefix: str,
+        use_postshuffle_norm: bool,
+        params_dtype=None,
+        device=None,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size * (config.spatial_merge_size**2)
+        self.use_postshuffle_norm = bool(use_postshuffle_norm)
+        norm_size = self.hidden_size if use_postshuffle_norm else config.hidden_size
+        self.norm = GR00TN17QwenLayerNorm(
+            norm_size,
+            eps=1e-6,
+            prefix=f"{prefix}.norm",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.linear_fc1 = GR00TN17QwenLinear(
+            self.hidden_size,
+            self.hidden_size,
+            bias=True,
+            prefix=f"{prefix}.linear_fc1",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.linear_fc2 = GR00TN17QwenLinear(
+            self.hidden_size,
+            config.out_hidden_size,
+            bias=True,
+            prefix=f"{prefix}.linear_fc2",
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.norm(x.view(-1, self.hidden_size) if self.use_postshuffle_norm else x)
+        x = x.view(-1, self.hidden_size)
+        return self.linear_fc2(F.gelu(self.linear_fc1(x)))
+
+
+def _apply_rotary_pos_emb_vision(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    orig_q_dtype = q.dtype
+    orig_k_dtype = k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.unsqueeze(-2).float(), sin.unsqueeze(-2).float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(orig_q_dtype), k_embed.to(orig_k_dtype)
+
+
+class GR00TN17QwenVisionAttention(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        prefix: str,
+        params_dtype=None,
+        device=None,
+        attention_backend: str = "sdpa",
+    ) -> None:
+        super().__init__()
+        self.dim = int(config.hidden_size)
+        self.num_heads = int(config.num_heads)
+        self.head_dim = self.dim // self.num_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_backend = attention_backend
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            causal=False,
+            backend=attention_backend,
+            backend_kwargs=_attention_backend_kwargs(attention_backend),
+        )
+        self.qkv = GR00TN17QwenLinear(
+            self.dim,
+            self.dim * 3,
+            bias=True,
+            prefix=f"{prefix}.qkv",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.proj = GR00TN17QwenLinear(
+            self.dim,
+            self.dim,
+            bias=True,
+            prefix=f"{prefix}.proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        seqlens: list[int] | None = None,
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        qkv = self.qkv(hidden_states)
+        query_states, key_states, value_states = (
+            qkv.reshape(seq_length, 3, self.num_heads, -1)
+            .permute(1, 0, 2, 3)
+            .unbind(0)
+        )
+        cos, sin = position_embeddings
+        query_states, key_states = _apply_rotary_pos_emb_vision(
+            query_states, key_states, cos, sin
+        )
+        if self.attention_backend == "sdpa" or (
+            self.attention_backend == "flashinfer" and not query_states.is_cuda
+        ):
+            query_states = query_states.transpose(0, 1).unsqueeze(0)
+            key_states = key_states.transpose(0, 1).unsqueeze(0)
+            value_states = value_states.transpose(0, 1).unsqueeze(0)
+            # Per-image (block-diagonal) attention. ``seqlens`` is the precomputed
+            # python segment-size list; when provided this avoids the
+            # ``cu_seqlens.tolist()`` host sync and is CUDA-graph-capturable.
+            # Byte-identical to deriving the lengths inline (same torch.split).
+            if seqlens is None:
+                seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+            splits = [
+                torch.split(tensor, seqlens, dim=2)
+                for tensor in (query_states, key_states, value_states)
+            ]
+            outs = [
+                _attention_forward(
+                    q,
+                    k,
+                    v,
+                    attention_mask=None,
+                    scaling=self.scaling,
+                )
+                for q, k, v in zip(*splits)
+            ]
+            out = torch.cat(outs, dim=1).reshape(seq_length, -1).contiguous()
+        else:
+            out = self.attn(
+                query_states,
+                key_states,
+                value_states,
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+            ).reshape(seq_length, -1).contiguous()
+        return self.proj(out)
+
+
+class GR00TN17QwenVisionBlock(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        prefix: str,
+        params_dtype=None,
+        device=None,
+        attention_backend: str = "sdpa",
+    ) -> None:
+        super().__init__()
+        self.norm1 = GR00TN17QwenLayerNorm(
+            config.hidden_size,
+            eps=1e-6,
+            prefix=f"{prefix}.norm1",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.norm2 = GR00TN17QwenLayerNorm(
+            config.hidden_size,
+            eps=1e-6,
+            prefix=f"{prefix}.norm2",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.attn = GR00TN17QwenVisionAttention(
+            config,
+            prefix=f"{prefix}.attn",
+            params_dtype=params_dtype,
+            device=device,
+            attention_backend=attention_backend,
+        )
+        self.mlp = GR00TN17QwenVisionMLP(
+            config,
+            prefix=f"{prefix}.mlp",
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        seqlens: list[int] | None = None,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens=cu_seqlens,
+            position_embeddings=position_embeddings,
+            seqlens=seqlens,
+        )
+        return hidden_states + self.mlp(self.norm2(hidden_states))
+
+
+@dataclass
+class GR00TN17QwenVisionOutput:
+    last_hidden_state: torch.Tensor
+    pooler_output: torch.Tensor
+    deepstack_features: list[torch.Tensor]
+
+
+class GR00TN17QwenVisionModel(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        prefix: str,
+        params_dtype=None,
+        device=None,
+        attention_backend: str = "sdpa",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.spatial_merge_size = int(config.spatial_merge_size)
+        self.spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
+        self.patch_embed = GR00TN17QwenConv3dPatchEmbed(
+            config,
+            prefix=f"{prefix}.patch_embed.proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.pos_embed = GR00TN17QwenEmbedding(
+            config.num_position_embeddings,
+            config.hidden_size,
+            prefix=f"{prefix}.pos_embed",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.num_grid_per_side = int(config.num_position_embeddings**0.5)
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = GR00TN17QwenVisionRotaryEmbedding(head_dim // 2)
+        self.blocks = nn.ModuleList(
+            [
+                GR00TN17QwenVisionBlock(
+                    config,
+                    prefix=f"{prefix}.blocks.{idx}",
+                    params_dtype=params_dtype,
+                    device=device,
+                    attention_backend=attention_backend,
+                )
+                for idx in range(config.depth)
+            ]
+        )
+        self.merger = GR00TN17QwenVisionPatchMerger(
+            config,
+            prefix=f"{prefix}.merger",
+            use_postshuffle_norm=False,
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.deepstack_visual_indexes = list(config.deepstack_visual_indexes)
+        self.deepstack_merger_list = nn.ModuleList(
+            [
+                GR00TN17QwenVisionPatchMerger(
+                    config,
+                    prefix=f"{prefix}.deepstack_merger_list.{idx}",
+                    use_postshuffle_norm=True,
+                    params_dtype=params_dtype,
+                    device=device,
+                )
+                for idx in range(len(self.deepstack_visual_indexes))
+            ]
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.weight.dtype
+
+    def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        max_hw = max(max(h, w) for _, h, w in grid_thw.tolist())
+        freq_table = self.rotary_pos_emb(max_hw)
+        # (total_patches, 2) merge-block-ordered (row, col) ids. Identical
+        # construction to the (now-removed) inline block-expand loop — same
+        # ordering and values, verified byte-for-byte — reused from the shared
+        # qwen3_vl helper. Indexing ``freq_table[pos_ids]`` is unchanged.
+        pos_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size)
+        return freq_table[pos_ids.to(freq_table.device)].flatten(1)
+
+    def fast_pos_embed_interpolate(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        grid_thw_list = grid_thw.tolist()
+        grid_ts = [row[0] for row in grid_thw_list]
+        grid_hs = [row[1] for row in grid_thw_list]
+        grid_ws = [row[2] for row in grid_thw_list]
+        device = self.pos_embed.weight.device
+        idx_list = [[] for _ in range(4)]
+        weight_list = [[] for _ in range(4)]
+        for t, h, w in grid_thw_list:
+            del t
+            h_idxs = torch.linspace(0, self.num_grid_per_side - 1, h)
+            w_idxs = torch.linspace(0, self.num_grid_per_side - 1, w)
+            h_floor = h_idxs.int()
+            w_floor = w_idxs.int()
+            h_ceil = (h_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+            w_ceil = (w_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+            dh = h_idxs - h_floor
+            dw = w_idxs - w_floor
+            base_h = h_floor * self.num_grid_per_side
+            base_h_ceil = h_ceil * self.num_grid_per_side
+            indices = [
+                (base_h[None].T + w_floor[None]).flatten(),
+                (base_h[None].T + w_ceil[None]).flatten(),
+                (base_h_ceil[None].T + w_floor[None]).flatten(),
+                (base_h_ceil[None].T + w_ceil[None]).flatten(),
+            ]
+            weights = [
+                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+                ((1 - dh)[None].T * dw[None]).flatten(),
+                (dh[None].T * (1 - dw)[None]).flatten(),
+                (dh[None].T * dw[None]).flatten(),
+            ]
+            for i in range(4):
+                idx_list[i].extend(indices[i].tolist())
+                weight_list[i].extend(weights[i].tolist())
+        idx_tensor = torch.tensor(idx_list, dtype=torch.long, device=device)
+        weight_tensor = torch.tensor(
+            weight_list, dtype=self.pos_embed.weight.dtype, device=device
+        )
+        pos_embeds = self.pos_embed(idx_tensor) * weight_tensor[:, :, None]
+        patch_pos_embeds = pos_embeds[0] + pos_embeds[1] + pos_embeds[2] + pos_embeds[3]
+        patch_pos_embeds = patch_pos_embeds.split(
+            [h * w for h, w in zip(grid_hs, grid_ws)]
+        )
+        out = []
+        merge_size = self.config.spatial_merge_size
+        for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
+            pos_embed = pos_embed.repeat(t, 1)
+            pos_embed = (
+                pos_embed.view(t, h // merge_size, merge_size, w // merge_size, merge_size, -1)
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            out.append(pos_embed)
+        return torch.cat(out)
+
+    def _vision_preamble(
+        self, grid_thw: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Grid-only vision preamble — NOT CUDA-graph-capturable.
+
+        Depends solely on ``grid_thw`` (constant for a fixed image size), so it
+        is hoisted out of the capturable core: ``fast_pos_embed_interpolate``
+        (``.tolist()``), ``rot_pos_emb`` (Python loop), and the
+        ``repeat_interleave`` cu_seqlens each force a host sync.
+        """
+        pos_embed = self.fast_pos_embed_interpolate(grid_thw)
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+        # Per-frame attention boundaries — identical to the (now-removed) inline
+        # ``repeat_interleave(...).cumsum(...).pad`` (verified byte-for-byte),
+        # reused from the shared qwen3_vl helper.
+        cu_seqlens = get_vision_cu_seqlens(grid_thw)
+        # Per-image segment sizes as a Python list (host sync here, in the
+        # non-capturable preamble) so the capturable core's attention can
+        # ``torch.split`` without a runtime ``.tolist()``.
+        seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        return pos_embed, rotary_pos_emb, cu_seqlens, seqlens
+
+    def _vision_core(
+        self,
+        hidden_states: torch.Tensor,
+        pos_embed: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        seqlens: list[int] | None = None,
+    ) -> GR00TN17QwenVisionOutput:
+        """Pure-tensor vision core — CUDA-graph-capturable.
+
+        Same ops/order as the original monolithic forward; only the grid-only
+        preamble has been hoisted to :meth:`_vision_preamble`.
+        """
+        hidden_states = self.patch_embed(hidden_states)
+        hidden_states = hidden_states + pos_embed
+        seq_len, _ = hidden_states.size()
+        rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1).to(
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (emb.cos(), emb.sin())
+        deepstack = []
+        for layer_num, block in enumerate(self.blocks):
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                position_embeddings=position_embeddings,
+                seqlens=seqlens,
+            )
+            if layer_num in self.deepstack_visual_indexes:
+                idx = self.deepstack_visual_indexes.index(layer_num)
+                deepstack.append(self.deepstack_merger_list[idx](hidden_states))
+        merged = self.merger(hidden_states)
+        return GR00TN17QwenVisionOutput(
+            last_hidden_state=hidden_states,
+            pooler_output=merged,
+            deepstack_features=deepstack,
+        )
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> GR00TN17QwenVisionOutput:
+        """Eager ViT forward. The CUDA-graph path captures ``_vision_core`` as
+        part of the merged backbone core (see
+        :meth:`GR00TN17NativeQwen3VLModel._backbone_core`); this module stays
+        stateless."""
+        pos_embed, rotary_pos_emb, cu_seqlens, seqlens = self._vision_preamble(grid_thw)
+        return self._vision_core(
+            hidden_states, pos_embed, rotary_pos_emb, cu_seqlens, seqlens=seqlens
+        )
+
+
+# ============================================================================ #
+#  Qwen3-VL text model                                                        #
+# ============================================================================ #
+
+
+class GR00TN17QwenTextRotaryEmbedding(nn.Module):
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        base = config.rope_theta
+        dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.attention_scaling = 1.0
+        self.mrope_section = list(config.mrope_section)
+
+    @staticmethod
+    def apply_interleaved_mrope(freqs: torch.Tensor, mrope_section: list[int]) -> torch.Tensor:
+        freqs_t = freqs[0].clone()
+        for dim, offset in enumerate((1, 2), start=1):
+            length = mrope_section[dim] * 3
+            idx = slice(offset, length, 3)
+            freqs_t[..., idx] = freqs[dim, ..., idx]
+        return freqs_t
+
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if position_ids.ndim == 2:
+            position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+        inv_freq = self.inv_freq.to(device=x.device)
+        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(
+            3, position_ids.shape[1], -1, 1
+        )
+        position_ids_expanded = position_ids[:, :, None, :].float()
+        freqs = (inv_freq_expanded @ position_ids_expanded).transpose(2, 3)
+        freqs = self.apply_interleaved_mrope(freqs, self.mrope_section)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        return emb.cos().to(dtype=x.dtype), emb.sin().to(dtype=x.dtype)
+
+
+def _apply_text_rotary(q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class GR00TN17QwenTextAttention(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        layer_idx: int,
+        *,
+        prefix: str,
+        params_dtype=None,
+        device=None,
+        attention_backend: str = "sdpa",
+    ) -> None:
+        super().__init__()
+        self.layer_idx = int(layer_idx)
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_heads = int(config.num_attention_heads)
+        self.num_key_value_heads = int(config.num_key_value_heads)
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_backend = attention_backend
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            num_kv_heads=self.num_key_value_heads,
+            causal=True,
+            backend=attention_backend,
+            backend_kwargs=_attention_backend_kwargs(attention_backend),
+        )
+        bias = bool(config.attention_bias)
+        self.q_proj = GR00TN17QwenLinear(
+            config.hidden_size,
+            self.num_heads * self.head_dim,
+            bias=bias,
+            prefix=f"{prefix}.q_proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.k_proj = GR00TN17QwenLinear(
+            config.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=bias,
+            prefix=f"{prefix}.k_proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.v_proj = GR00TN17QwenLinear(
+            config.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=bias,
+            prefix=f"{prefix}.v_proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.o_proj = GR00TN17QwenLinear(
+            self.num_heads * self.head_dim,
+            config.hidden_size,
+            bias=bias,
+            prefix=f"{prefix}.o_proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.q_norm = GR00TN17QwenRMSNorm(
+            self.head_dim,
+            eps=config.rms_norm_eps,
+            prefix=f"{prefix}.q_norm",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.k_norm = GR00TN17QwenRMSNorm(
+            self.head_dim,
+            eps=config.rms_norm_eps,
+            prefix=f"{prefix}.k_norm",
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        input_shape = hidden_states.shape[:-1]
+        q_shape = (*input_shape, self.num_heads, self.head_dim)
+        kv_shape = (*input_shape, self.num_key_value_heads, self.head_dim)
+        q = self.q_norm(self.q_proj(hidden_states).view(q_shape)).transpose(1, 2)
+        k = self.k_norm(self.k_proj(hidden_states).view(kv_shape)).transpose(1, 2)
+        v = self.v_proj(hidden_states).view(kv_shape).transpose(1, 2)
+        cos, sin = position_embeddings
+        q, k = _apply_text_rotary(q, k, cos, sin)
+        if (
+            attention_mask is None
+            and (self.attention_backend != "flashinfer" or q.is_cuda)
+        ):
+            out = self.attn(
+                q.transpose(1, 2),
+                k.transpose(1, 2),
+                v.transpose(1, 2),
+            )
+        else:
+            out = _attention_forward(
+                q,
+                k,
+                v,
+                attention_mask=attention_mask,
+                scaling=self.scaling,
+                num_key_value_groups=self.num_key_value_groups,
+                is_causal=attention_mask is None,
+            )
+        out = out.reshape(*input_shape, -1).contiguous()
+        return self.o_proj(out)
+
+
+class GR00TN17QwenTextMLP(nn.Module):
+    def __init__(self, config: Any, *, prefix: str, params_dtype=None, device=None) -> None:
+        super().__init__()
+        self.gate_proj = GR00TN17QwenLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=False,
+            prefix=f"{prefix}.gate_proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.up_proj = GR00TN17QwenLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=False,
+            prefix=f"{prefix}.up_proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.down_proj = GR00TN17QwenLinear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=False,
+            prefix=f"{prefix}.down_proj",
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(_silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class GR00TN17QwenTextDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        layer_idx: int,
+        *,
+        prefix: str,
+        params_dtype=None,
+        device=None,
+        attention_backend: str = "sdpa",
+    ) -> None:
+        super().__init__()
+        self.self_attn = GR00TN17QwenTextAttention(
+            config,
+            layer_idx,
+            prefix=f"{prefix}.self_attn",
+            params_dtype=params_dtype,
+            device=device,
+            attention_backend=attention_backend,
+        )
+        self.mlp = GR00TN17QwenTextMLP(
+            config,
+            prefix=f"{prefix}.mlp",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.input_layernorm = GR00TN17QwenRMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+            prefix=f"{prefix}.input_layernorm",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.post_attention_layernorm = GR00TN17QwenRMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+            prefix=f"{prefix}.post_attention_layernorm",
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+        )
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class GR00TN17QwenTextModel(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        num_layers: int,
+        prefix: str,
+        params_dtype=None,
+        device=None,
+        attention_backend: str = "sdpa",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.embed_tokens = GR00TN17QwenEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=f"{prefix}.embed_tokens",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.layers = nn.ModuleList(
+            [
+                GR00TN17QwenTextDecoderLayer(
+                    config,
+                    idx,
+                    prefix=f"{prefix}.layers.{idx}",
+                    params_dtype=params_dtype,
+                    device=device,
+                    attention_backend=attention_backend,
+                )
+                for idx in range(num_layers)
+            ]
+        )
+        self.norm = GR00TN17QwenRMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+            prefix=f"{prefix}.norm",
+            params_dtype=params_dtype,
+            device=device,
+        )
+        self.rotary_emb = GR00TN17QwenTextRotaryEmbedding(config)
+
+    def _causal_mask(
+        self,
+        inputs_embeds: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        text_position_ids: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        if text_position_ids is None and (
+            attention_mask is None or bool(attention_mask.bool().all())
+        ):
+            return None
+        batch, seq_len, _ = inputs_embeds.shape
+        min_dtype = torch.finfo(inputs_embeds.dtype).min
+        if text_position_ids is None:
+            causal = torch.ones(
+                seq_len,
+                seq_len,
+                dtype=torch.bool,
+                device=inputs_embeds.device,
+            ).triu(diagonal=1)
+            causal = causal[None, None, :, :].expand(batch, 1, -1, -1)
+        else:
+            causal = text_position_ids[:, None, :] > text_position_ids[:, :, None]
+            causal = causal[:, None, :, :].to(device=inputs_embeds.device)
+        mask = torch.zeros(batch, 1, seq_len, seq_len, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
+        mask = mask.masked_fill(causal, min_dtype)
+        if attention_mask is not None:
+            key_padding = attention_mask[:, None, None, :].to(device=inputs_embeds.device).bool()
+            mask = mask.masked_fill(~key_padding, min_dtype)
+        return mask
+
+    def _deepstack_process(
+        self,
+        hidden_states: torch.Tensor,
+        visual_index: torch.Tensor,
+        visual_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        """Add ``visual_embeds`` to the visual-token rows of ``hidden_states``.
+
+        Uses ``index_add_`` with a precomputed integer ``visual_index`` instead
+        of boolean-mask indexing (``hidden_states[mask] += ...``), which calls
+        ``nonzero`` and is not CUDA-graph-capturable. Byte-identical: each visual
+        row receives exactly its one ``visual_embeds`` row, same order.
+        """
+        visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
+        hidden_states = hidden_states.clone()
+        flat = hidden_states.reshape(-1, hidden_states.shape[-1])
+        flat.index_add_(0, visual_index, visual_embeds)
+        return hidden_states
+
+    def _llm_core(
+        self,
+        inputs_embeds: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        visual_index: torch.Tensor,
+        deepstack_visual_embeds: list[torch.Tensor],
+        attention_mask: torch.Tensor | None = None,
+    ) -> SimpleNamespace:
+        """Pure-tensor decoder stack — CUDA-graph-capturable.
+
+        ``attention_mask`` is either ``None`` for the original no-padding fast
+        path or a precomputed 4-D additive causal/key-padding mask for graph
+        sequence buckets. Computing the mask stays in the host-sync preamble;
+        the captured region only reads the static mask buffer.
+        """
+        hidden_states = inputs_embeds
+        for layer_idx, layer in enumerate(self.layers):
+            hidden_states = layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=attention_mask,
+            )
+            if layer_idx < len(deepstack_visual_embeds):
+                hidden_states = self._deepstack_process(
+                    hidden_states, visual_index, deepstack_visual_embeds[layer_idx]
+                )
+        return SimpleNamespace(
+            last_hidden_state=self.norm(hidden_states),
+            pre_norm_hidden_state=hidden_states,
+            hidden_states=None,
+        )
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor | None,
+        inputs_embeds: torch.Tensor | None,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        visual_pos_masks: torch.Tensor | None,
+        deepstack_visual_embeds: list[torch.Tensor] | None,
+        output_hidden_states: bool,
+    ) -> SimpleNamespace:
+        """Eager decoder forward. The CUDA-graph path captures ``_llm_core`` as
+        part of the merged backbone core (see
+        :meth:`GR00TN17NativeQwen3VLModel._backbone_core`); this stays stateless."""
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("input_ids or inputs_embeds is required.")
+            inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids.ndim == 3 and position_ids.shape[0] == 4:
+            text_position_ids = position_ids[0]
+            rope_position_ids = position_ids[1:]
+            # Footgun guard: in the 4-row layout, row 0 is the causal-mask key
+            # (token i attends j iff row0[j] <= row0[i] in _causal_mask), so it must
+            # be strictly increasing per sample, i.e. real text/sequence positions.
+            # Passing an M-RoPE coordinate row here (e.g. the temporal row, where every
+            # image patch in a frame shares one value) silently makes image tokens
+            # attend each other bidirectionally and diverges from the standard-causal
+            # backbone. Production never enters this branch (the runner feeds 3-row
+            # M-RoPE via prepare_position_ids); fail loudly rather than mis-attend.
+            if text_position_ids.shape[-1] > 1 and not bool(
+                (text_position_ids[:, 1:] > text_position_ids[:, :-1]).all()
+            ):
+                raise ValueError(
+                    "GR00TN17QwenTextModel got 4-row position_ids whose row 0 is not "
+                    "strictly increasing. Row 0 must be the text/sequence positions used "
+                    "for causal masking; you likely passed an M-RoPE coordinate row "
+                    "(e.g. temporal) by mistake. Feed 3-row M-RoPE position_ids "
+                    "(as backbone.prepare_position_ids does), or a valid text-position row."
+                )
+        elif position_ids.ndim == 3:
+            text_position_ids = None
+            rope_position_ids = position_ids
+        else:
+            text_position_ids = position_ids
+            rope_position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+        attention_mask_4d = self._causal_mask(
+            inputs_embeds, attention_mask, text_position_ids
+        )
+        position_embeddings = self.rotary_emb(inputs_embeds, rope_position_ids)
+        # Flat integer indices of visual-token rows (host sync here, outside any
+        # captured region) for the capture-safe deepstack add.
+        visual_index = None
+        if deepstack_visual_embeds is not None and visual_pos_masks is not None:
+            visual_index = (
+                visual_pos_masks.reshape(-1)
+                .to(inputs_embeds.device)
+                .nonzero(as_tuple=True)[0]
+            )
+        hidden_states = inputs_embeds
+        all_hidden_states = [hidden_states] if output_hidden_states else None
+        for layer_idx, layer in enumerate(self.layers):
+            hidden_states = layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=attention_mask_4d,
+            )
+            if visual_index is not None and layer_idx < len(deepstack_visual_embeds):
+                hidden_states = self._deepstack_process(
+                    hidden_states,
+                    visual_index,
+                    deepstack_visual_embeds[layer_idx],
+                )
+            if output_hidden_states:
+                all_hidden_states.append(hidden_states)
+        final_hidden_states = self.norm(hidden_states)
+        return SimpleNamespace(
+            last_hidden_state=final_hidden_states,
+            # Pre-final-norm features — what the GR00T backbone consumes. Returned
+            # directly (instead of a forward_pre_hook on ``norm``) so the value
+            # survives CUDA-graph replay, where Python hooks do not re-fire.
+            pre_norm_hidden_state=hidden_states,
+            hidden_states=tuple(all_hidden_states) if output_hidden_states else None,
+        )
+
+
+class GR00TN17NativeQwen3VLModel(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        select_layer: int,
+        params_dtype=None,
+        device=None,
+        attention_backend: str = "sdpa",
+        prefix: str = "backbone.model.model",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.visual = GR00TN17QwenVisionModel(
+            config.vision,
+            prefix=f"{prefix}.visual",
+            params_dtype=params_dtype,
+            device=device,
+            attention_backend=attention_backend,
+        )
+        num_layers = config.text.num_hidden_layers if select_layer < 0 else select_layer
+        self.language_model = GR00TN17QwenTextModel(
+            config.text,
+            num_layers=num_layers,
+            prefix=f"{prefix}.language_model",
+            params_dtype=params_dtype,
+            device=device,
+            attention_backend=attention_backend,
+        )
+
+    def get_input_embeddings(self):
+        return self.language_model.embed_tokens
+
+    def get_vision_position_ids(
+        self,
+        start_position: int,
+        grid_thw: torch.Tensor,
+        temp_merge_size: int = 1,
+        spatial_merge_size: int = 1,
+        time_interval: int = 1,
+        device: str | torch.device | None = None,
+    ) -> torch.Tensor:
+        llm_grid_t = grid_thw[0].item() // temp_merge_size
+        llm_grid_h = grid_thw[1].item() // spatial_merge_size
+        llm_grid_w = grid_thw[2].item() // spatial_merge_size
+        position_temporal = torch.arange(llm_grid_t, device=device) * time_interval
+        position_width = torch.arange(llm_grid_w, device=device) + start_position
+        position_height = torch.arange(llm_grid_h, device=device) + start_position
+        position_width = position_width.repeat(llm_grid_h * llm_grid_t)
+        position_height = position_height.repeat_interleave(llm_grid_w).repeat(llm_grid_t)
+        position_temporal = (
+            position_temporal.repeat_interleave(llm_grid_h * llm_grid_w) + start_position
+        )
+        return torch.stack([position_temporal, position_height, position_width], dim=0)
+
+    def get_rope_index(
+        self,
+        input_ids: torch.Tensor,
+        mm_token_type_ids: torch.Tensor,
+        image_grid_thw: torch.Tensor | None,
+        video_grid_thw: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if video_grid_thw is not None:
+            video_grid_thw = torch.repeat_interleave(video_grid_thw, video_grid_thw[:, 0], dim=0)
+            video_grid_thw[:, 0] = 1
+        spatial_merge_size = self.config.vision.spatial_merge_size
+        position_ids = torch.zeros(
+            3,
+            input_ids.shape[0],
+            input_ids.shape[1],
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        mrope_position_deltas = []
+        grid_iters = {
+            1: iter(image_grid_thw) if image_grid_thw is not None else None,
+            2: iter(video_grid_thw) if video_grid_thw is not None else None,
+        }
+        for batch_idx, current_input_ids in enumerate(input_ids):
+            input_type = mm_token_type_ids[batch_idx]
+            if attention_mask is not None:
+                current_input_ids = current_input_ids[attention_mask[batch_idx].bool()]
+                input_type = input_type[attention_mask[batch_idx].bool()]
+            groups = []
+            for key, group in itertools.groupby(enumerate(input_type.tolist()), lambda x: x[1]):
+                group = list(group)
+                groups.append((key, group[0][0], group[-1][0] + 1))
+            current_pos = 0
+            pos_list = []
+            for modality_type, start_idx, end_idx in groups:
+                if modality_type == 0:
+                    text_len = end_idx - start_idx
+                    pos_list.append(
+                        torch.arange(text_len, device=input_ids.device)
+                        .view(1, -1)
+                        .expand(3, -1)
+                        + current_pos
+                    )
+                    current_pos += text_len
+                else:
+                    grid_thw = next(grid_iters[modality_type])
+                    vision_position_ids = self.get_vision_position_ids(
+                        current_pos,
+                        grid_thw,
+                        1,
+                        spatial_merge_size,
+                        device=input_ids.device,
+                    )
+                    pos_list.append(vision_position_ids)
+                    current_pos += max(grid_thw[1], grid_thw[2]) // spatial_merge_size
+            llm_positions = torch.cat(pos_list, dim=1).reshape(3, -1)
+            if attention_mask is not None:
+                position_ids[:, batch_idx, attention_mask[batch_idx].bool()] = llm_positions
+            else:
+                position_ids[:, batch_idx] = llm_positions
+            mrope_position_deltas.append(llm_positions.max() + 1 - len(current_input_ids))
+        return position_ids, torch.tensor(mrope_position_deltas, device=input_ids.device).unsqueeze(1)
+
+    def get_image_features(
+        self,
+        pixel_values: torch.Tensor,
+        image_grid_thw: torch.Tensor,
+    ) -> GR00TN17QwenVisionOutput:
+        vision_output = self.visual(
+            pixel_values.type(self.visual.dtype), grid_thw=image_grid_thw
+        )
+        split_sizes = (image_grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
+        vision_output.pooler_output = torch.split(vision_output.pooler_output, split_sizes)
+        return vision_output
+
+    def get_placeholder_mask(
+        self,
+        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+        image_features: torch.Tensor,
+    ) -> torch.Tensor:
+        mask = input_ids == self.config.image_token_id
+        expanded = mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+        if inputs_embeds[expanded].numel() != image_features.numel():
+            raise ValueError(
+                "Image features and image tokens do not match: "
+                f"tokens={int(mask.sum())}, features={tuple(image_features.shape)}"
+            )
+        return expanded
+
+    def _backbone_core(
+        self,
+        *,
+        pixel_values: torch.Tensor,
+        pos_embed: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        input_ids: torch.Tensor,
+        image_index: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        attention_mask_4d: torch.Tensor | None,
+        seqlens: list[int],
+    ) -> SimpleNamespace:
+        """Merged ViT + multimodal fuse + LLM decoder — ONE capturable region.
+
+        Every host-sync preamble (vision grid geometry, 3-D M-RoPE position ids
+        -> cos/sin, the image-token ``image_index``) is computed by the caller
+        and passed in as buffers, so this entire forward is pure tensor ops and
+        captures as a single CUDA graph. ``index_copy_`` (capture-safe) replaces
+        the boolean ``masked_scatter`` for vision-token fusion. Deepstack
+        features flow from the ViT taps into the decoder within the same graph.
+        """
+        vision_out = self.visual._vision_core(
+            pixel_values, pos_embed, rotary_pos_emb, cu_seqlens, seqlens=seqlens
+        )
+        merged = vision_out.pooler_output  # (total_vision_tokens, hidden)
+        deepstack = vision_out.deepstack_features
+        inputs_embeds = self.language_model.embed_tokens(input_ids)
+        inputs_embeds.view(-1, inputs_embeds.shape[-1]).index_copy_(
+            0, image_index, merged.to(inputs_embeds.dtype)
+        )
+        return self.language_model._llm_core(
+            inputs_embeds, (cos, sin), image_index, deepstack, attention_mask_4d
+        )
+
+    def backbone_graph_plan(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        pixel_values: torch.Tensor,
+        image_grid_thw: torch.Tensor,
+        mm_token_type_ids: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        graph_seq_len_buckets: tuple[int, ...] | None = None,
+        output_hidden_states: bool = False,
+        **_: Any,
+    ) -> tuple[Any, dict[str, torch.Tensor], tuple, dict[str, torch.Tensor]] | None:
+        """Host-sync preamble for the single-graph backbone path.
+
+        Returns ``(core_fn, buffers, key, model_inputs)`` ready for the
+        **runner** to capture/replay :meth:`_backbone_core`, or ``None`` when the
+        input is not graph-eligible (then the runner falls back to the eager
+        :meth:`forward`).
+        Eligible == on CUDA, 3-row M-RoPE position ids, dumping off. When
+        ``graph_seq_len_buckets`` is provided, left-pad text tensors to the
+        smallest bucket that fits the current sequence, preserving the official
+        Qwen tokenizer's left-padding semantics.
+        No capture happens here, so this module holds no graph state.
+        """
+        if not pixel_values.is_cuda or output_hidden_states:
+            return None
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids, dtype=torch.long)
+        if mm_token_type_ids is None:
+            mm_token_type_ids = torch.zeros_like(input_ids, dtype=torch.int32)
+            mm_token_type_ids = mm_token_type_ids.masked_fill(input_ids == self.config.image_token_id, 1)
+        seq_len = int(input_ids.shape[1])
+        if graph_seq_len_buckets is not None:
+            bucket = next((b for b in graph_seq_len_buckets if seq_len <= b), None)
+            if bucket is None:
+                return None
+            pad = int(bucket) - seq_len
+            if pad > 0:
+                input_ids = F.pad(input_ids, (pad, 0), value=0)
+                attention_mask = F.pad(attention_mask, (pad, 0), value=0)
+                mm_token_type_ids = F.pad(mm_token_type_ids, (pad, 0), value=0)
+                if position_ids is not None:
+                    position_ids = F.pad(position_ids, (pad, 0), value=0)
+        if position_ids is None:
+            position_ids, _ = self.get_rope_index(
+                input_ids,
+                mm_token_type_ids,
+                image_grid_thw=image_grid_thw,
+                attention_mask=attention_mask,
+            )
+        if not (
+            position_ids.ndim == 3
+            and position_ids.shape[0] == 3
+        ):
+            return None
+        pixel_values = pixel_values.type(self.visual.dtype)
+        device = pixel_values.device
+        pos_embed, rotary_pos_emb, cu_seqlens, seqlens = self.visual._vision_preamble(
+            image_grid_thw
+        )
+        rotary_pos_emb = rotary_pos_emb.to(device)
+        # 3-D M-RoPE cos/sin (pixel_values is only a dtype/device reference here).
+        cos, sin = self.language_model.rotary_emb(pixel_values, position_ids)
+        mask_ref = torch.empty(
+            (*input_ids.shape, 1),
+            dtype=self.language_model.embed_tokens.weight.dtype,
+            device=input_ids.device,
+        )
+        attention_mask_4d = self.language_model._causal_mask(
+            mask_ref,
+            attention_mask,
+            text_position_ids=None,
+        )
+        image_index = (input_ids.reshape(-1) == self.config.image_token_id).nonzero(
+            as_tuple=True
+        )[0]
+        buffers = {
+            "pixel_values": pixel_values,
+            "pos_embed": pos_embed,
+            "rotary_pos_emb": rotary_pos_emb,
+            "cu_seqlens": cu_seqlens,
+            "input_ids": input_ids,
+            "image_index": image_index,
+            "cos": cos,
+            "sin": sin,
+        }
+        if attention_mask_4d is not None:
+            buffers["attention_mask_4d"] = attention_mask_4d
+        model_inputs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+            "mm_token_type_ids": mm_token_type_ids,
+            "position_ids": position_ids,
+        }
+        key = (
+            tuple(pixel_values.shape),
+            pixel_values.dtype,
+            tuple(input_ids.shape),
+            tuple(cos.shape),
+            tuple(image_index.shape),
+            None if attention_mask_4d is None else tuple(attention_mask_4d.shape),
+            tuple(seqlens),
+        )
+
+        # ``seqlens`` is a Python list (not a graph buffer); bake it into the core
+        # via a closure (the key includes it, so reuse stays shape-correct).
+        def core(**buf: torch.Tensor) -> SimpleNamespace:
+            return self._backbone_core(
+                pixel_values=buf["pixel_values"],
+                pos_embed=buf["pos_embed"],
+                rotary_pos_emb=buf["rotary_pos_emb"],
+                cu_seqlens=buf["cu_seqlens"],
+                input_ids=buf["input_ids"],
+                image_index=buf["image_index"],
+                cos=buf["cos"],
+                sin=buf["sin"],
+                attention_mask_4d=buf.get("attention_mask_4d"),
+                seqlens=seqlens,
+            )
+
+        return core, buffers, key, model_inputs
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        pixel_values: torch.Tensor,
+        image_grid_thw: torch.Tensor,
+        mm_token_type_ids: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        output_hidden_states: bool = False,
+        **_: Any,
+    ) -> SimpleNamespace:
+        """Eager backbone forward (byte-identical reference). The CUDA-graph path
+        captures :meth:`_backbone_core` from the runner via
+        :meth:`backbone_graph_plan`; this module holds no graph state."""
+        if mm_token_type_ids is None:
+            mm_token_type_ids = torch.zeros_like(input_ids, dtype=torch.int32)
+            mm_token_type_ids = mm_token_type_ids.masked_fill(input_ids == self.config.image_token_id, 1)
+        if position_ids is None:
+            position_ids, _ = self.get_rope_index(
+                input_ids,
+                mm_token_type_ids,
+                image_grid_thw=image_grid_thw,
+                attention_mask=attention_mask,
+            )
+        inputs_embeds = self.get_input_embeddings()(input_ids)
+        image_outputs = self.get_image_features(pixel_values, image_grid_thw)
+        image_embeds = torch.cat(image_outputs.pooler_output, dim=0).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        image_mask = self.get_placeholder_mask(input_ids, inputs_embeds, image_embeds)
+        # Capture-safe scatter (matches the graph path): place each merged vision
+        # token onto its image-token row by precomputed index. Byte-identical to
+        # the boolean ``masked_scatter`` (same positions/order).
+        image_index = (input_ids.reshape(-1) == self.config.image_token_id).nonzero(
+            as_tuple=True
+        )[0]
+        inputs_embeds.view(-1, inputs_embeds.shape[-1]).index_copy_(
+            0, image_index, image_embeds
+        )
+        visual_pos_masks = image_mask[..., 0]
+        deepstack_visual_embeds = image_outputs.deepstack_features
+        return self.language_model(
+            input_ids=None,
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+            output_hidden_states=output_hidden_states,
+        )
+
+
+class GR00TN17NativeQwen3VLForConditionalGeneration(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        select_layer: int,
+        params_dtype=None,
+        device=None,
+        attention_backend: str = "sdpa",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.model = GR00TN17NativeQwen3VLModel(
+            config,
+            select_layer=select_layer,
+            params_dtype=params_dtype,
+            device=device,
+            attention_backend=attention_backend,
+        )
+        self.lm_head = GR00TN17QwenLinear(
+            config.text.hidden_size,
+            config.text.vocab_size,
+            bias=False,
+            prefix="backbone.model.lm_head",
+            params_dtype=params_dtype,
+            device=device,
+        )
+
+    def forward(self, **kwargs: Any) -> SimpleNamespace:
+        return self.model(**kwargs)
+
+
+__all__ = ["GR00TN17NativeQwen3VLForConditionalGeneration"]

--- a/phyai/src/phyai/models/gr00t_n17/qwen3_vl_native.py
+++ b/phyai/src/phyai/models/gr00t_n17/qwen3_vl_native.py
@@ -49,7 +49,7 @@ def _attach_replicated_hf_key(param: nn.Parameter, hf_key: str) -> None:
 
 
 def _replicated_linear(linear: ReplicatedLinear, x: torch.Tensor) -> torch.Tensor:
-    out, bias = ReplicatedLinear.forward(linear, x)
+    out, bias = linear(x)
     if bias is not None:
         return out + bias
     return out
@@ -122,7 +122,10 @@ class GR00TN17QwenLinear(ReplicatedLinear):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _replicated_linear(self, x)
+        out, bias = super().forward(x)
+        if bias is not None:
+            return out + bias
+        return out
 
 
 class GR00TN17QwenRMSNorm(nn.Module):
@@ -660,7 +663,7 @@ class GR00TN17QwenVisionModel(nn.Module):
 
     def _vision_preamble(
         self, grid_thw: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, list[int]]:
         """Grid-only vision preamble — NOT CUDA-graph-capturable.
 
         Depends solely on ``grid_thw`` (constant for a fixed image size), so it
@@ -1494,6 +1497,16 @@ class GR00TN17NativeQwen3VLModel(nn.Module):
         image_index = (input_ids.reshape(-1) == self.config.image_token_id).nonzero(
             as_tuple=True
         )[0]
+        expected_image_tokens = int(
+            (image_grid_thw.prod(-1) // self.visual.spatial_merge_size**2)
+            .sum()
+            .item()
+        )
+        if int(image_index.numel()) != expected_image_tokens:
+            raise ValueError(
+                "Image features and image tokens do not match: "
+                f"tokens={int(image_index.numel())}, features={expected_image_tokens}."
+            )
         buffers = {
             "pixel_values": pixel_values,
             "pos_embed": pos_embed,

--- a/phyai/src/phyai/models/gr00t_n17/scheduler_ws1_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/scheduler_ws1_gr00t_n17.py
@@ -60,7 +60,9 @@ class GR00TN17WS1Scheduler(Scheduler):
         self.model = model
         self.model.eval()
         self.max_batch_size = int(max_batch_size)
-        self.device = torch.device(device) if device is not None else torch.device("cpu")
+        self.device = (
+            torch.device(device) if device is not None else torch.device("cpu")
+        )
         self.use_cuda_graph = bool(use_cuda_graph)
         self.backbone_runner = GR00TN17BackboneRunner(model)
         self.action_head_runner = GR00TN17ActionHeadRunner(

--- a/phyai/src/phyai/models/gr00t_n17/scheduler_ws1_gr00t_n17.py
+++ b/phyai/src/phyai/models/gr00t_n17/scheduler_ws1_gr00t_n17.py
@@ -1,0 +1,107 @@
+"""GR00T-N1.7 single-GPU scheduler boundary.
+
+The engine is strict about inputs: image transform, Qwen3-VL
+patchify, tokenization, and state/action normalization are the **caller's**
+responsibility (see ``phyai_utils_tools.models.gr00t.GR00TProcessor``). The
+scheduler consumes the already-prepared model-input tensors and returns the raw
+normalized action chunk; the caller decodes it back to physical units. This
+keeps the engine free of any processor / tokenizer dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from phyai.models.gr00t_n17.model_runner_gr00t_n17 import (
+    GR00TN17ActionHeadRunner,
+    GR00TN17BackboneRunner,
+)
+from phyai.models.gr00t_n17.modeling_gr00t_n17 import (
+    GR00TN17Model,
+)
+from phyai.runtime.schedule import Scheduler
+
+
+@dataclass(frozen=True)
+class GR00TN17Request:
+    """One GR00T-N1.7 inference request — prepared model-input tensors.
+
+    ``tensors`` is exactly the dict produced by the out-of-engine processor
+    (``GR00TProcessor.process_observation(obs).tensors``): ``state`` /
+    ``embodiment_id`` / ``action_mask`` plus the VLM tensors (``pixel_values``,
+    ``input_ids``, ``attention_mask``, ``image_grid_thw``, ``mm_token_type_ids``).
+    ``noise`` optionally seeds the flow-matching sampler for deterministic runs.
+    """
+
+    tensors: dict[str, torch.Tensor]
+    noise: torch.Tensor | None = None
+
+
+class GR00TN17WS1Scheduler(Scheduler):
+    """Single-rank GR00T-N1.7 inference scheduler.
+
+    The scheduler owns runner order and the denoising request lifecycle. It does
+    not own preprocessing: it receives prepared tensors and emits the normalized
+    action chunk.
+    """
+
+    def __init__(
+        self,
+        model: GR00TN17Model,
+        *,
+        max_batch_size: int = 1,
+        device: torch.device | str | None = None,
+        use_cuda_graph: bool = True,
+    ) -> None:
+        if max_batch_size <= 0:
+            raise ValueError(f"max_batch_size must be positive, got {max_batch_size}.")
+        self.model = model
+        self.model.eval()
+        self.max_batch_size = int(max_batch_size)
+        self.device = torch.device(device) if device is not None else torch.device("cpu")
+        self.use_cuda_graph = bool(use_cuda_graph)
+        self.backbone_runner = GR00TN17BackboneRunner(model)
+        self.action_head_runner = GR00TN17ActionHeadRunner(
+            model,
+            max_batch_size=self.max_batch_size,
+            device=self.device,
+            use_cuda_graph=self.use_cuda_graph,
+        )
+
+    def setup(self) -> None:
+        self.backbone_runner.setup()
+        self.action_head_runner.setup()
+
+    @torch.no_grad()
+    def step(self, request: GR00TN17Request) -> torch.Tensor:
+        """Run backbone + action-head denoising; return the normalized action.
+
+        Returns the ``(B, action_horizon, max_action_dim)`` normalized action
+        chunk. The caller maps it back to physical units via the processor's
+        ``decode_action`` (which needs the per-request ``raw_state``).
+        """
+        tensors = request.tensors
+        batch = tensors["state"].shape[0]
+        if batch > self.max_batch_size:
+            raise ValueError(
+                "GR00T-N1.7 request batch exceeds scheduler max_batch_size: "
+                f"{batch} > {self.max_batch_size}."
+            )
+        backbone_inputs, action_inputs = self.model.prepare_input(
+            tensors, device=self.device
+        )
+        backbone_output = self.backbone_runner.forward(backbone_inputs)
+        normalized_action = self.action_head_runner.forward(
+            backbone_output, action_inputs, noise=request.noise
+        )
+        return normalized_action
+
+    def close(self) -> None:
+        self.backbone_runner.close()
+        self.action_head_runner.close()
+        return None
+
+
+__all__ = ["GR00TN17Request", "GR00TN17WS1Scheduler"]


### PR DESCRIPTION
## Summary

This PR adds native GR00T-N1.7 model support to PhyAI.

## Changes

- Register the `gr00t_n17` model entry in the engine.
- Add GR00T-N1.7 model components:
  - Qwen3-VL/Cosmos backbone adapter
  - action head
  - WS1 scheduler
  - model runner
- Add GR00T preprocessing utilities under `phyai-utils-tools`.
- Update package dependencies required by the GR00T processor/model path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the GR00T-N1.7 model, including a checkpoint-agnostic processor for multimodal preprocessing and action decoding.
  * Introduced native deterministic image handling plus configurable state/action normalization and relative-to-absolute action conversion.
  * Added a new single-GPU scheduling path with an inference runner that returns normalized action outputs for later decoding.
  * Enabled the model to be discovered by the engine as a registered plugin, with optional CUDA-graph acceleration when compatible.
* **Chores**
  * Updated dependencies (including image support) and added an optional fast tokenizer extra.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->