### PR TITLE
feat(phyai): data-parallel (wn) inference for pi05

### DIFF
--- a/examples/pi05/run_pi05_wn.py
+++ b/examples/pi05/run_pi05_wn.py
@@ -1,0 +1,173 @@
+"""End-to-end pi0.5 data-parallel demo under torchrun (DP=N, TP=1).
+
+Multi-GPU ("wn") sibling of ``run_pi05.py``. Drives the ``pi05_wn`` engine
+plugin: a full pi0.5 replica per GPU, the ``--batch-size`` request split
+statically across ``--dp`` GPUs (each card runs ``ceil(batch/dp)`` robots), rank
+0 scatters the shards and gathers the action chunks back. Only rank 0 holds the
+final ``(batch, chunk, action_dim)`` tensor.
+
+Launch under torchrun with ``--nproc_per_node`` equal to ``--dp``::
+
+    torchrun --nproc_per_node=8 examples/pi05/run_pi05_wn.py --dp 8 \\
+        --checkpoint /path/to/pi05_base/ --batch-size 32
+
+Inputs are random (canonical tensors); action numbers are meaningless. This
+verifies the DP wiring + timing. Requires CUDA + NCCL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import time
+
+import torch
+
+
+def _resolve_topology(dp: int) -> tuple[int, int, bool]:
+    """Reconcile ``--dp`` with the torchrun launch env.
+
+    Returns ``(local_rank, dp, is_main)``. World size == dp (one process/rank).
+    ``dp == 1`` runs in-process (no torchrun needed). Rank 0 is the Router and
+    holds the gathered result.
+    """
+    world = dp
+    env_world = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world > 1 and env_world != world:
+        raise SystemExit(
+            f"--dp {dp} requires torchrun --nproc_per_node={world} "
+            f"(saw WORLD_SIZE={env_world}). Example:\n"
+            f"  torchrun --nproc_per_node={world} examples/pi05/run_pi05_wn.py "
+            f"--dp {dp} --checkpoint <ckpt> --batch-size 32"
+        )
+    if world == 1 and env_world != 1:
+        raise SystemExit(
+            f"launched under torchrun (WORLD_SIZE={env_world}) but --dp is 1; "
+            f"set --dp to use all ranks."
+        )
+    return local_rank, dp, local_rank == 0
+
+
+@contextlib.contextmanager
+def _timed(label: str, store: dict):
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        store[label] = time.perf_counter() - t0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--checkpoint", required=True, help="pi05_base checkpoint dir")
+    parser.add_argument(
+        "--dp",
+        type=int,
+        default=1,
+        help="Data-parallel degree; world_size = dp must equal torchrun --nproc_per_node.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Total robots across all ranks (split ceil(batch/dp) per card).",
+    )
+    parser.add_argument("--num-images", type=int, default=3)
+    parser.add_argument(
+        "--vision-dtype", choices=("bfloat16", "float32"), default="bfloat16"
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required.")
+
+    from phyai.engine import Engine, EngineArgs
+    from phyai.engine_config import (
+        DeviceConfig,
+        EngineConfig,
+        ParallelConfig,
+        RuntimeConfig,
+    )
+    from phyai.models.pi05.configuration_pi05 import PI05Config
+    from phyai.models.pi05.main_pi05_wn import PI05WNArgs
+    from phyai.models.pi05.scheduler_ws1_pi05 import PI05Request
+    from phyai.utils import load_config
+
+    local_rank, dp_size, is_main = _resolve_topology(args.dp)
+    device = f"cuda:{local_rank}"
+    dtype = torch.bfloat16
+    vision_dtype = torch.float32 if args.vision_dtype == "float32" else None
+
+    def log(*a, **k):
+        if is_main:
+            print(*a, **k)
+
+    plugin_cfg = load_config(args.checkpoint, PI05Config)
+    inputs_image_shape = [
+        [plugin_cfg.vision.image_size, plugin_cfg.vision.image_size, 3]
+        for _ in range(args.num_images)
+    ]
+
+    log(f"[engine] creating pi0.5 data-parallel engine (dp={dp_size})...")
+    engine = Engine(
+        EngineArgs(
+            plugin="pi05_wn",
+            plugin_args=PI05WNArgs(
+                checkpoint_dir=args.checkpoint,
+                max_batch_size=args.batch_size,
+                vision_params_dtype=vision_dtype,
+                inputs_image_shape=inputs_image_shape,
+            ),
+            config=EngineConfig(
+                device=DeviceConfig(target=device, params_dtype=dtype),
+                parallel=ParallelConfig(world_size=dp_size, dp_size=dp_size, tp_size=1),
+                runtime=RuntimeConfig(use_cuda_graph=True),
+            ),
+        )
+    )
+
+    timings: dict[str, float] = {}
+    try:
+        # Every rank builds a full canonical request; only rank 0's rows are
+        # scattered (others' copies are ignored — they recv their shard).
+        B = args.batch_size
+        img = plugin_cfg.vision.image_size
+        request = PI05Request(
+            pixel_values=torch.rand(
+                B, args.num_images, 3, img, img, dtype=dtype, device=device
+            ),
+            input_ids=torch.zeros(
+                B, plugin_cfg.tokenizer_max_length, dtype=torch.int64, device=device
+            ),
+            lang_lens=torch.ones(B, dtype=torch.int64, device=device),
+        )
+        request.input_ids[:, 0] = 2
+
+        with _timed("warmup", timings):
+            engine.step(request)
+        with _timed("inference", timings):
+            actions = engine.step(request)
+
+        if is_main:
+            print(f"[run] dp={dp_size} total_batch={B}")
+            print(f"action chunk shape : {tuple(actions.shape)}")
+            print(f"action chunk device: {actions.device}")
+            print(f"first action row   : {actions[0, 0].float().tolist()}")
+            print(
+                f"timing (s): warmup={timings['warmup']:.2f} "
+                f"inference={timings['inference']:.2f}"
+            )
+    finally:
+        engine.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/phyai/src/phyai/engine.py
+++ b/phyai/src/phyai/engine.py
@@ -389,6 +389,7 @@ __all__ = [
 
 from phyai.models.pi0 import main_pi0 as _main_pi0  # noqa: E402, F401
 from phyai.models.pi05 import main_pi05 as _main_pi05  # noqa: E402, F401
+from phyai.models.pi05 import main_pi05_wn as _main_pi05_wn  # noqa: E402, F401
 from phyai.models.cosmos3 import main_cosmos3 as _main_cosmos3  # noqa: E402, F401
 from phyai.models.cosmos3 import (  # noqa: E402, F401
     main_cosmos3_policy as _main_cosmos3_policy,

--- a/phyai/src/phyai/models/pi05/main_pi05_wn.py
+++ b/phyai/src/phyai/models/pi05/main_pi05_wn.py
@@ -1,0 +1,138 @@
+"""pi0.5 data-parallel ("wn") plugin entry — the engine's pi0.5 DP hook.
+
+Sibling of :mod:`phyai.models.pi05.main_pi05`. Identical model build + weight
+load (a full replica per rank), except it sizes the single-card
+:class:`PI05WS1Scheduler` for the per-rank shard and wraps it in a
+:class:`~phyai.models.pi05.scheduler_wn_pi05.PI05WNScheduler`.
+
+The engine bootstrap (``init_dist`` -> ``P.init`` 6-axis mesh -> ``L.init``) runs
+before :meth:`setup`, so the ``dp`` axis is live here and ``per_rank_B`` can be
+derived from it. Drive DP via ``ParallelConfig(world_size=N, dp_size=N,
+tp_size=1)`` and launch one process per rank under ``torchrun`` (see
+``examples/pi05/run_pi05_wn.py``). ``max_batch_size`` on the args is the TOTAL
+batch across all ranks; each rank processes ``ceil(max_batch_size / dp_size)``.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, ClassVar
+
+import torch
+
+from phyai.engine import Engine, Entry, EntryArgs
+from phyai.engine_config import get_engine_config
+from phyai.layers.quant.active import load_quant_plan, use_quant_plan
+from phyai.models.pi05.configuration_pi05 import PI05Config
+from phyai.models.pi05.main_pi05 import PI05Entry, _compose_remap
+from phyai.models.pi05.modeling_pi05 import PI05Model
+from phyai.models.pi05.scheduler_wn_pi05 import PI05WNScheduler, _dp_rank_size
+from phyai.models.pi05.scheduler_ws1_pi05 import PI05Request, PI05WS1Scheduler
+from phyai.utils import load_config, this_rank_log
+from phyai.weights import load_pretrained
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PI05WNArgs(EntryArgs):
+    """Args bundle for the pi0.5 data-parallel plugin.
+
+    Same shape as :class:`~phyai.models.pi05.main_pi05.PI05Args`, except
+    ``max_batch_size`` is the **total** batch across all ``dp`` ranks (e.g. 32
+    for the 8-GPU demo); the per-rank ws1 is sized ``ceil(max_batch_size /
+    dp_size)``.
+    """
+
+    checkpoint_dir: str | Path | None = None
+    config: PI05Config | None = None
+    max_batch_size: int = 1
+    weight_remap: Callable[[str], str | None] | dict[str, str] | None = None
+    weight_strict: bool = True
+    vision_params_dtype: torch.dtype | None = None
+    inputs_image_shape: list[list[int]] | None = None
+
+
+@Engine.register
+class PI05WNEntry(Entry):
+    """pi0.5 data-parallel inference plugin entry."""
+
+    name: ClassVar[str] = "pi05_wn"
+    args_cls: ClassVar[type[EntryArgs]] = PI05WNArgs
+
+    def __init__(self) -> None:
+        self.model: PI05Model | None = None
+        self.scheduler: PI05WNScheduler | None = None
+
+    def setup(self, args: PI05WNArgs) -> None:  # type: ignore[override]
+        eng = get_engine_config()
+
+        if args.config is not None:
+            config = args.config
+        elif args.checkpoint_dir is not None:
+            config = load_config(args.checkpoint_dir, PI05Config)
+        else:
+            config = PI05Config()
+
+        # Reuse pi05's recommended-engine overlay + num-image validation.
+        eng = PI05Entry._apply_recommended_engine(eng, config)
+
+        with use_quant_plan(load_quant_plan(args.checkpoint_dir)):
+            self.model = PI05Model(
+                config,
+                vision_params_dtype=args.vision_params_dtype,
+                device=eng.device.target,
+            )
+        if args.checkpoint_dir is not None:
+            load_pretrained(
+                self.model,
+                args.checkpoint_dir,
+                remap=_compose_remap(args.weight_remap),
+                strict=args.weight_strict,
+            )
+        num_images = PI05Entry._resolve_num_images(args.inputs_image_shape, config)
+
+        _, dp_size = _dp_rank_size()
+        per_rank_B = math.ceil(args.max_batch_size / dp_size)
+        local = PI05WS1Scheduler(
+            self.model,
+            max_batch_size=per_rank_B,
+            num_images=num_images,
+            device=eng.device.target,
+            use_cuda_graph=eng.runtime.use_cuda_graph,
+        )
+        self.scheduler = PI05WNScheduler(local, device=eng.device.target)
+        self.scheduler.setup()
+        this_rank_log(
+            logger,
+            logging.INFO,
+            "pi0.5 DP plugin ready (dp=%d, total_batch=%d, per_rank_B=%d).",
+            dp_size,
+            args.max_batch_size,
+            per_rank_B,
+        )
+
+    def step(self, request: PI05Request) -> torch.Tensor:  # type: ignore[override]
+        if self.scheduler is None:
+            raise RuntimeError(
+                "PI05WNEntry.step called before setup; the scheduler is None."
+            )
+        return self.scheduler.step(request)
+
+    def close(self) -> None:
+        if self.scheduler is not None:
+            self.scheduler.close()
+            self.scheduler = None
+        self.model = None
+
+    def dump_targets(self) -> dict[str, torch.nn.Module]:  # type: ignore[override]
+        if self.model is None:
+            return {}
+        return {"model": self.model}
+
+
+__all__ = ["PI05WNArgs", "PI05WNEntry"]

--- a/phyai/src/phyai/models/pi05/scheduler_wn_pi05.py
+++ b/phyai/src/phyai/models/pi05/scheduler_wn_pi05.py
@@ -1,0 +1,191 @@
+"""pi0.5 data-parallel ("wn") scheduler — shard the batch over the dp axis.
+
+Data parallelism for pi0.5 inference: every rank holds a full model replica
+(tp=cfg=1) and processes a contiguous shard of the request batch. Rank 0 is the
+Router — it holds the incoming batch, scatters each rank's shard over the mesh
+``dp`` axis with point-to-point ``send``/``recv``, every rank runs the composed
+single-card :class:`PI05WS1Scheduler` on its shard, and the per-rank action
+chunks are recombined with one ``all_gather`` over ``dp`` back to rank 0.
+
+Unlike cosmos3's CFG-parallel scheduler (which folds an all-gather *inside* the
+denoise loop), pi0.5 DP is request-level: no in-loop communication, so this
+scheduler composes the battle-tested ws1 compute unchanged instead of rewriting
+its loop. At ``dp_size == 1`` every collective short-circuits and this degenerates
+to a plain single-card run.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import torch.distributed as dist
+
+import phyai.parallel as P
+from phyai.models.pi05.scheduler_ws1_pi05 import PI05Request, PI05WS1Scheduler
+from phyai.runtime.schedule import Scheduler
+from phyai.utils import this_rank_log
+
+
+logger = logging.getLogger(__name__)
+
+
+def _dp_rank_size() -> tuple[int, int]:
+    """Current ``(dp_rank, dp_size)`` on the data-parallel axis.
+
+    ``(0, 1)`` when there is no mesh / no ``dp`` axis (single-process runs),
+    matching how the tp/cfg helpers degrade in the cosmos3 schedulers.
+    """
+    try:
+        mesh = P.default_mesh()
+        return mesh.axis_local_rank("dp"), mesh.axis_size("dp")
+    except Exception:
+        return 0, 1
+
+
+def _pad_rows(t: torch.Tensor, total: int) -> torch.Tensor:
+    """Pad/truncate ``t`` along dim 0 to exactly ``total`` rows.
+
+    Growing repeats the last row (kept valid rather than zeroed, so a padded
+    ``lang_lens`` stays a real length); the padded tail is discarded after the
+    gather anyway. Shrinking takes the first ``total`` rows.
+    """
+    b = t.shape[0]
+    if b == total:
+        return t
+    if b > total:
+        return t[:total].contiguous()
+    pad = t[-1:].expand(total - b, *t.shape[1:])
+    return torch.cat([t, pad], dim=0).contiguous()
+
+
+class PI05WNScheduler(Scheduler):
+    """Data-parallel pi0.5 orchestrator (rank-0 Router + dp-axis scatter/gather)."""
+
+    def __init__(
+        self,
+        local: PI05WS1Scheduler,
+        *,
+        device: torch.device | str | None = None,
+    ) -> None:
+        self.local = local
+        self.device = torch.device(device) if device is not None else local.device
+        self.dtype = local.params_dtype
+        self.cfg = local.cfg
+        self.num_images = local.num_images
+        # Each rank's ws1 is sized for the per-rank shard; that IS per_rank_B.
+        self.per_rank_B = local.max_batch_size
+        self.dp_rank, self.dp_size = _dp_rank_size()
+
+    def setup(self) -> None:
+        if self.dp_size > 1:
+            world = dist.get_world_size() if dist.is_initialized() else 1
+            if world != self.dp_size:
+                raise RuntimeError(
+                    f"PI05WNScheduler assumes pure data parallelism (tp=cfg=1): "
+                    f"dp_size={self.dp_size} must equal world_size={world}. The "
+                    f"point-to-point scatter addresses peers by dp-axis-local rank, "
+                    f"which equals the global rank only when the dp group spans the "
+                    f"world."
+                )
+        self.local.setup()
+        this_rank_log(
+            logger,
+            logging.INFO,
+            "pi0.5 DP scheduler ready (dp=%d, per_rank_B=%d).",
+            self.dp_size,
+            self.per_rank_B,
+        )
+
+    @torch.no_grad()
+    def step(self, request: PI05Request) -> torch.Tensor:
+        """Scatter the batch across dp, run ws1 per rank, gather actions to rank 0.
+
+        Returns ``(real_B, chunk, action_dim)`` on rank 0 (the Router) and the
+        full ``(dp_size*per_rank_B, chunk, action_dim)`` on other ranks (ignored
+        by the launcher, which only persists rank 0's output).
+        """
+        if self.dp_size == 1:
+            return self.local.step(request)
+
+        real_B = int(request.pixel_values.shape[0]) if self.dp_rank == 0 else 0
+        if self.dp_rank == 0:
+            # Fatal misconfiguration guard. Only rank 0 knows real_B, so this
+            # raises on rank 0 alone; peers are already blocked in ``recv``
+            # inside ``_scatter`` and hang until the launcher (torchrun) reaps
+            # them. That is acceptable for a caller-side programming error — a
+            # symmetric raise would cost a broadcast on every (valid) step.
+            capacity = self.dp_size * self.per_rank_B
+            if real_B > capacity:
+                raise ValueError(
+                    f"PI05WNScheduler: batch {real_B} exceeds DP capacity "
+                    f"dp_size*per_rank_B={capacity}."
+                )
+        shard = self._scatter(request)
+        local_actions = self.local.step(shard)  # (per_rank_B, chunk, action_dim)
+        gathered = P.all_gather(local_actions, axis="dp", dim=0)
+        if self.dp_rank == 0:
+            return gathered[:real_B].clone()
+        return gathered
+
+    def _scatter(self, request: PI05Request) -> PI05Request:
+        """Rank 0 splits the padded batch and sends each shard; others receive.
+
+        Fields moved: ``pixel_values``/``noise`` (model dtype) and
+        ``input_ids``/``lang_lens`` (int64). Every rank ends with exactly
+        ``per_rank_B`` rows. When ``request.noise is None`` the Router samples one
+        noise tensor and scatters it, so all shards share a single noise source.
+        """
+        R, N, pr = self.dp_rank, self.dp_size, self.per_rank_B
+        dev, dt, cfg = self.device, self.dtype, self.cfg
+        chunk, act = cfg.chunk_size, cfg.max_action_dim
+        px_shape = (
+            pr,
+            self.num_images,
+            cfg.vision.num_channels,
+            cfg.vision.image_size,
+            cfg.vision.image_size,
+        )
+        ids_shape = (pr, cfg.tokenizer_max_length)
+        lens_shape = (pr,)
+        noise_shape = (pr, chunk, act)
+
+        if R == 0:
+            total = N * pr
+            px = _pad_rows(request.pixel_values.to(dev, dt), total)
+            ids = _pad_rows(request.input_ids.to(dev, torch.int64), total)
+            lens = _pad_rows(request.lang_lens.to(dev, torch.int64), total)
+            if request.noise is not None:
+                noise_src = request.noise.to(dev, dt)
+            else:
+                noise_src = torch.randn(
+                    request.pixel_values.shape[0], chunk, act, device=dev, dtype=dt
+                )
+            noise = _pad_rows(noise_src, total)
+
+            def shard(t: torch.Tensor, r: int) -> torch.Tensor:
+                return t[r * pr : (r + 1) * pr].contiguous()
+
+            for r in range(1, N):
+                P.send(shard(px, r), axis="dp", dst=r)
+                P.send(shard(ids, r), axis="dp", dst=r)
+                P.send(shard(lens, r), axis="dp", dst=r)
+                P.send(shard(noise, r), axis="dp", dst=r)
+            return PI05Request(
+                pixel_values=shard(px, 0),
+                input_ids=shard(ids, 0),
+                lang_lens=shard(lens, 0),
+                noise=shard(noise, 0),
+            )
+
+        px = P.recv(px_shape, dt, axis="dp", src=0, device=dev)
+        ids = P.recv(ids_shape, torch.int64, axis="dp", src=0, device=dev)
+        lens = P.recv(lens_shape, torch.int64, axis="dp", src=0, device=dev)
+        noise = P.recv(noise_shape, dt, axis="dp", src=0, device=dev)
+        return PI05Request(pixel_values=px, input_ids=ids, lang_lens=lens, noise=noise)
+
+    def close(self) -> None:
+        self.local.close()
+
+
+__all__ = ["PI05WNScheduler"]


### PR DESCRIPTION
## Summary

Adds a data-parallel inference path for pi0.5 (`pi05_wn`): the request batch is sharded across GPUs (DP=N, TP=1), each GPU runs a full model replica, and rank 0 scatters the shards over the mesh `dp` axis then gathers the action chunks back. 

## What's added

- `scheduler_wn_pi05.py` — `PI05WNScheduler`: composes `PI05WS1Scheduler` for per-rank compute; rank-0 Router does `send`/`recv` scatter over `axis="dp"` and one `all_gather` to recombine.
- `main_pi05_wn.py` — the `pi05_wn` engine plugin; one replica per rank, per-rank batch = `ceil(total_batch / dp_size)`.
- `examples/pi05/run_pi05_wn.py` — torchrun demo.
- `engine.py` — plugin registration (one line).

## Notes

- First consumer of the mesh `dp` axis; uses the existing collectives with `axis="dp"`, so no changes to `phyai.parallel` / `phyai.layers` / `phyai.runtime`.
- DP is request-level (no in-loop communication), so the WN scheduler reuses the existing `ws1` logic.
- `tp =  1` (pure DP), asserted in `setup()`; `batch` should be divisible by `dp`. At `dp_size == 1` the collectives short-circuit to plain single-card behavior.
  
## Validation
  
- DP output is bit-identical to the single-card `ws1` path on the same inputs + noise.
- End-to-end run on real `pi05_base` weights produces the expected `(batch, chunk, action_dim)` output.
  
## Run
  
```bash
torchrun --nproc_per_node=8 examples/pi05/run_pi05_wn.py \
    --dp 8 --checkpoint /path/to/pi05_base --batch-size 32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `pi05_wn` engine for data-parallel inference across multiple GPUs.
  * Supports configurable checkpoints, vision data types, batch sizes, and weight loading.
  * Added an end-to-end `torchrun` example with warmup, inference timing, and sample output reporting.
  * Automatically distributes requests across GPUs and combines generated actions into the final batch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->