### PR TITLE
feat(phyai-kernel): add Thor NVFP4 GeGLU kernel for pi0.5

### DIFF
--- a/phyai-kernel/benchmark/bench_pi05_thor_nvfp4_geglu.py
+++ b/phyai-kernel/benchmark/bench_pi05_thor_nvfp4_geglu.py
@@ -1,0 +1,249 @@
+"""Benchmark the fixed pi0.5 Thor NVFP4 GeGLU kernel.
+
+The baseline has the same packed-NVFP4 input and output contract, but stages
+FlashInfer NVFP4 GEMM, PyTorch GeGLU, and FlashInfer NVFP4 quantization. Both
+paths are captured into CUDA Graphs before timing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import Callable
+
+import torch
+import torch.nn.functional as F
+from flashinfer import gemm as flashinfer_gemm
+from flashinfer.quantization import SfLayout, nvfp4_quantize
+
+from phyai_kernel.cuda.pi05_thor_nvfp4_geglu import (
+    HIDDEN_SIZE,
+    INTERMEDIATE_SIZE,
+    MERGED_SIZE,
+    SUPPORTED_M,
+    nvfp4_scale_shape,
+    pi05_thor_nvfp4_geglu,
+)
+
+
+def _capture(function: Callable[[], object]) -> tuple[torch.cuda.CUDAGraph, object]:
+    for _ in range(5):
+        result = function()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        result = function()
+    return graph, result
+
+
+def _time_graph(graph: torch.cuda.CUDAGraph, iterations: int) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        graph.replay()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+def _benchmark_shape(
+    m: int,
+    interleaved_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    *,
+    seed: int,
+    warmup: int,
+    samples: int,
+    iterations: int,
+) -> dict[str, object]:
+    generator = torch.Generator(device="cuda").manual_seed(seed + m)
+    activation_bf16 = torch.randn(
+        m,
+        HIDDEN_SIZE,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    activation, activation_scale = nvfp4_quantize(
+        activation_bf16,
+        global_scale,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+        enable_pdl=False,
+    )
+    workspace = torch.zeros(m, INTERMEDIATE_SIZE, dtype=torch.uint8, device="cuda")
+    output = torch.empty(m, INTERMEDIATE_SIZE // 2, dtype=torch.uint8, device="cuda")
+    output_scale = torch.empty(
+        nvfp4_scale_shape(m, INTERMEDIATE_SIZE),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    staged_merged = torch.empty(m, MERGED_SIZE, dtype=torch.bfloat16, device="cuda")
+
+    def candidate() -> tuple[torch.Tensor, torch.Tensor]:
+        return pi05_thor_nvfp4_geglu(
+            activation,
+            activation_scale,
+            interleaved_weight,
+            weight_scale,
+            workspace,
+            output,
+            output_scale,
+        )
+
+    def baseline() -> tuple[torch.Tensor, torch.Tensor]:
+        merged = flashinfer_gemm.mm_fp4(
+            activation,
+            interleaved_weight.t(),
+            activation_scale,
+            weight_scale.t().view(torch.uint8),
+            global_scale,
+            torch.bfloat16,
+            staged_merged,
+            block_size=16,
+            use_nvfp4=True,
+            backend="cudnn",
+            enable_pdl=False,
+        )
+        hidden = F.gelu(merged[:, 0::2], approximate="tanh") * merged[:, 1::2]
+        return nvfp4_quantize(
+            hidden,
+            global_scale,
+            sfLayout=SfLayout.layout_128x4,
+            do_shuffle=False,
+            enable_pdl=False,
+        )
+
+    candidate_graph, candidate_result = _capture(candidate)
+    baseline_graph, baseline_result = _capture(baseline)
+    # Keep graph-captured intermediates alive for the full timing region.
+    graph_storage = (candidate_result, baseline_result, staged_merged)
+
+    for _ in range(warmup):
+        candidate_graph.replay()
+        baseline_graph.replay()
+    torch.cuda.synchronize()
+
+    candidate_samples: list[float] = []
+    baseline_samples: list[float] = []
+    for sample_index in range(samples):
+        order = (
+            (("candidate", candidate_graph), ("baseline", baseline_graph))
+            if sample_index % 2 == 0
+            else (("baseline", baseline_graph), ("candidate", candidate_graph))
+        )
+        for name, graph in order:
+            elapsed = _time_graph(graph, iterations)
+            if name == "candidate":
+                candidate_samples.append(elapsed)
+            else:
+                baseline_samples.append(elapsed)
+
+    del graph_storage
+    candidate_median = statistics.median(candidate_samples)
+    baseline_median = statistics.median(baseline_samples)
+    return {
+        "m": m,
+        "candidate_ms": candidate_median,
+        "baseline_ms": baseline_median,
+        "speedup": baseline_median / candidate_median,
+        "delta_percent": (candidate_median / baseline_median - 1.0) * 100.0,
+        "candidate_raw_ms": candidate_samples,
+        "baseline_raw_ms": baseline_samples,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m", default=",".join(str(m) for m in sorted(SUPPORTED_M)))
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--samples", type=int, default=30)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=20260814)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (11, 0):
+        raise RuntimeError("this benchmark requires an SM110 CUDA device")
+    shapes = [int(value) for value in args.m.split(",") if value]
+    if any(m not in SUPPORTED_M for m in shapes):
+        raise ValueError(f"supported M values are {sorted(SUPPORTED_M)}")
+    if args.warmup < 0 or args.samples <= 0 or args.iterations <= 0:
+        raise ValueError("warmup must be non-negative; samples and iterations positive")
+
+    generator = torch.Generator(device="cuda").manual_seed(args.seed)
+    weight_bf16 = (
+        torch.randn(
+            MERGED_SIZE,
+            HIDDEN_SIZE,
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.02
+    )
+    global_scale = torch.ones(1, dtype=torch.float32, device="cuda")
+    interleaved_weight, weight_scale = nvfp4_quantize(
+        weight_bf16,
+        global_scale,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+        enable_pdl=False,
+    )
+
+    rows = [
+        _benchmark_shape(
+            m,
+            interleaved_weight,
+            weight_scale,
+            global_scale,
+            seed=args.seed,
+            warmup=args.warmup,
+            samples=args.samples,
+            iterations=args.iterations,
+        )
+        for m in shapes
+    ]
+    candidate_geomean = math.exp(
+        statistics.fmean(math.log(float(row["candidate_ms"])) for row in rows)
+    )
+    baseline_geomean = math.exp(
+        statistics.fmean(math.log(float(row["baseline_ms"])) for row in rows)
+    )
+    report = {
+        "schema": "phyai.pi05_thor_nvfp4_geglu.benchmark.v1",
+        "device": torch.cuda.get_device_name(),
+        "compute_capability": list(torch.cuda.get_device_capability()),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "baseline": "FlashInfer NVFP4 GEMM + PyTorch GeGLU + FlashInfer NVFP4 quantize",
+        "timing": {
+            "mode": "CUDA Graph replay with CUDA events",
+            "warmup": args.warmup,
+            "samples": args.samples,
+            "iterations_per_sample": args.iterations,
+            "rotated_order": True,
+        },
+        "rows": rows,
+        "geomean": {
+            "candidate_ms": candidate_geomean,
+            "baseline_ms": baseline_geomean,
+            "speedup": baseline_geomean / candidate_geomean,
+            "delta_percent": (candidate_geomean / baseline_geomean - 1.0) * 100.0,
+        },
+    }
+    serialized = json.dumps(report, indent=2, sort_keys=True)
+    print(serialized)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/phyai-kernel/phyai_kernel/__init__.py
+++ b/phyai-kernel/phyai_kernel/__init__.py
@@ -3,6 +3,11 @@
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 from phyai_kernel import jit_utils
+from phyai_kernel.cuda import (
+    nvfp4_scale_shape,
+    pi05_thor_nvfp4_geglu,
+    supports_pi05_thor_nvfp4_geglu,
+)
 from phyai_kernel.jit_utils import jit
 from phyai_kernel.triton import (
     adarmsnorm,
@@ -35,7 +40,10 @@ __all__ = [
     "jit_utils",
     "layernorm",
     "masked_embedding_lookup",
+    "nvfp4_scale_shape",
+    "pi05_thor_nvfp4_geglu",
     "rmsnorm",
     "rmsnorm_hf",
     "rmsnorm_silu_mul",
+    "supports_pi05_thor_nvfp4_geglu",
 ]

--- a/phyai-kernel/phyai_kernel/cuda/__init__.py
+++ b/phyai-kernel/phyai_kernel/cuda/__init__.py
@@ -1,5 +1,15 @@
 """phyai-kernel CUDA kernels."""
 
 from . import jit  # noqa: F401
+from .pi05_thor_nvfp4_geglu import (
+    nvfp4_scale_shape,
+    pi05_thor_nvfp4_geglu,
+    supports_pi05_thor_nvfp4_geglu,
+)
 
-__all__ = ["jit"]
+__all__ = [
+    "jit",
+    "nvfp4_scale_shape",
+    "pi05_thor_nvfp4_geglu",
+    "supports_pi05_thor_nvfp4_geglu",
+]

--- a/phyai-kernel/phyai_kernel/cuda/csrc/pi05_thor_nvfp4_geglu.cuh
+++ b/phyai-kernel/phyai_kernel/cuda/csrc/pi05_thor_nvfp4_geglu.cuh
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Fixed-shape SM110 NVFP4 Gate+Up GEMM with compact GeGLU output for pi0.5.
+
+#pragma once
+
+#include <cstdint>
+
+#include <cuda_runtime.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/detail/sm100_blockscaled_layout.hpp>
+#include <cutlass/epilogue/collective/collective_builder.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>
+#include <cutlass/gemm/device/gemm_universal_adapter.h>
+#include <cutlass/gemm/kernel/gemm_universal.hpp>
+#include <cutlass/util/packed_stride.hpp>
+#include <cute/tensor.hpp>
+#include <tvm/ffi/container/tensor.h>
+
+#include "pi05_thor_nvfp4_geglu_epilogue.cuh"
+
+namespace phyai::pi05::thor {
+
+using namespace cute;
+
+using MmaTile = Shape<_128, _256, _256>;
+using Cluster = Shape<_1, _2, _1>;
+using ElementA = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+using ElementB = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+using ElementD = cutlass::float_e2m1_t;
+using ElementC = ElementD;
+using ElementSFD = cutlass::float_ue4m3_t;
+using ElementAccumulator = float;
+using ElementCompute = float;
+using ArchTag = cutlass::arch::Sm100;
+using OperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+
+constexpr int kAlignmentA = 32;
+constexpr int kAlignmentB = 32;
+constexpr int kAlignmentC = 32;
+constexpr int kAlignmentD = 32;
+constexpr int kScaleVector = 16;
+
+using Fusion = detail::CompactGeGLUFusion<kScaleVector, ElementD, ElementCompute, ElementSFD,
+                                          cutlass::layout::RowMajor, ElementC>;
+
+using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+    ArchTag, OperatorClass, MmaTile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator,
+    ElementAccumulator, ElementC, cutlass::layout::RowMajor, kAlignmentC, ElementD, cutlass::layout::RowMajor, kAlignmentD,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+
+using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+    ArchTag, OperatorClass, ElementA, cutlass::layout::RowMajor, kAlignmentA, ElementB, cutlass::layout::ColumnMajor,
+    kAlignmentB, ElementAccumulator, MmaTile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+using Kernel = cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, Mainloop, Epilogue, void>;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+using StrideA = typename Kernel::StrideA;
+using StrideB = typename Kernel::StrideB;
+using StrideC = typename Kernel::StrideC;
+using StrideD = typename Kernel::StrideD;
+using BlockScaledConfig = typename Mainloop::Sm1xxBlkScaledConfig;
+
+inline int run(const void* activation, const void* activation_scale, const void* interleaved_weight, const void* weight_scale,
+               void* workspace, void* output, void* output_scale, int m, int n, int k, cudaStream_t stream) {
+  auto stride_a = cutlass::make_cute_packed_stride(StrideA{}, {m, k, 1});
+  auto stride_b = cutlass::make_cute_packed_stride(StrideB{}, {n, k, 1});
+  auto stride_c = cutlass::make_cute_packed_stride(StrideC{}, {m, n, 1});
+  auto stride_d = cutlass::make_cute_packed_stride(StrideD{}, {m, n, 1});
+  auto layout_sfa = BlockScaledConfig::tile_atom_to_shape_SFA(make_shape(m, n, k, 1));
+  auto layout_sfb = BlockScaledConfig::tile_atom_to_shape_SFB(make_shape(m, n, k, 1));
+
+  using AData = typename ElementA::DataType;
+  using AScale = typename ElementA::ScaleFactorType;
+  using BData = typename ElementB::DataType;
+  using BScale = typename ElementB::ScaleFactorType;
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {m, n, k, 1},
+      {reinterpret_cast<const AData*>(activation), stride_a, reinterpret_cast<const BData*>(interleaved_weight), stride_b,
+       reinterpret_cast<const AScale*>(activation_scale), layout_sfa, reinterpret_cast<const BScale*>(weight_scale),
+       layout_sfb},
+      {{1.0f, 0.0f}, reinterpret_cast<ElementC*>(workspace), stride_c, reinterpret_cast<ElementD*>(workspace), stride_d}};
+  arguments.epilogue.thread.output = reinterpret_cast<uint8_t*>(output);
+  arguments.epilogue.thread.output_scale = reinterpret_cast<uint8_t*>(output_scale);
+
+  Gemm gemm;
+  auto status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) { return static_cast<int>(status) | 0x10000; }
+  if (Gemm::get_workspace_size(arguments) != 0) { return -3; }
+  status = gemm.initialize(arguments, nullptr, stream);
+  if (status != cutlass::Status::kSuccess) { return static_cast<int>(status) | 0x20000; }
+  status = gemm.run(stream);
+  return status == cutlass::Status::kSuccess ? 0 : (static_cast<int>(status) | 0x30000);
+}
+
+}  // namespace phyai::pi05::thor
+
+extern "C" int phyai_pi05_thor_nvfp4_geglu(tvm::ffi::TensorView activation, tvm::ffi::TensorView activation_scale,
+                                           tvm::ffi::TensorView interleaved_weight, tvm::ffi::TensorView weight_scale,
+                                           tvm::ffi::TensorView workspace, tvm::ffi::TensorView output,
+                                           tvm::ffi::TensorView output_scale, int64_t m, int64_t stream_handle) {
+  if ((m != 784 && m != 816 && m != 880 && m != 968) || activation.size(0) != m) { return -2; }
+  auto data = [](const tvm::ffi::TensorView& tensor) {
+    return static_cast<void*>(static_cast<char*>(tensor.data_ptr()) + tensor.byte_offset());
+  };
+  return phyai::pi05::thor::run(data(activation), data(activation_scale), data(interleaved_weight), data(weight_scale),
+                                data(workspace), data(output), data(output_scale), static_cast<int>(m), 32768, 2048,
+                                reinterpret_cast<cudaStream_t>(stream_handle));
+}

--- a/phyai-kernel/phyai_kernel/cuda/csrc/pi05_thor_nvfp4_geglu_epilogue.cuh
+++ b/phyai-kernel/phyai_kernel/cuda/csrc/pi05_thor_nvfp4_geglu_epilogue.cuh
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// Compact GeGLU and NVFP4 output callback for the fixed pi0.5 Thor kernel.
+
+#pragma once
+
+#include <cstdint>
+
+#include <cuda_fp8.h>
+#include <cute/tensor.hpp>
+#include <cutlass/cutlass.h>
+#include <cutlass/detail/sm100_blockscaled_layout.hpp>
+#include <cutlass/epilogue/fusion/operations.hpp>
+#include <cutlass/epilogue/fusion/sm100_callbacks_tma_warpspecialized.hpp>
+#include <cutlass/epilogue/fusion/sm100_visitor_store_tma_warpspecialized.hpp>
+
+namespace phyai::pi05::thor::detail {
+
+using namespace cute;
+
+template <int kVectorSize, class EpilogueTile, class ElementOutput, class ElementCompute, class ElementScale,
+          cutlass::FloatRoundStyle kRoundStyle = cutlass::FloatRoundStyle::round_to_nearest>
+struct CompactGeGLUStoreNode {
+  static_assert(size<1>(EpilogueTile{}) % (2 * kVectorSize) == 0,
+                "the epilogue tile must contain complete gate/up scale blocks");
+
+  struct SharedStorage {};
+
+  struct Arguments {
+    uint8_t* output = nullptr;
+    uint8_t* output_scale = nullptr;
+  };
+
+  using Params = Arguments;
+
+  template <class ProblemShape>
+  static constexpr Params to_underlying_arguments(ProblemShape const&, Arguments const& arguments, void*) {
+    return arguments;
+  }
+
+  template <class ProblemShape>
+  static bool can_implement(ProblemShape const& problem_shape, Arguments const& arguments) {
+    auto shape = append<4>(problem_shape, 1);
+    const auto columns = get<1>(shape);
+    return columns % (2 * kVectorSize) == 0 && arguments.output != nullptr && arguments.output_scale != nullptr;
+  }
+
+  template <class ProblemShape>
+  static size_t get_workspace_size(ProblemShape const&, Arguments const&) {
+    return 0;
+  }
+
+  template <class ProblemShape>
+  static cutlass::Status initialize_workspace(ProblemShape const&, Arguments const&, void*, cudaStream_t,
+                                              cutlass::CudaHostAdapter* = nullptr) {
+    return cutlass::Status::kSuccess;
+  }
+
+  CUTLASS_HOST_DEVICE CompactGeGLUStoreNode() = default;
+
+  CUTLASS_HOST_DEVICE CompactGeGLUStoreNode(Params const& params, SharedStorage const&) : params_(&params) {}
+
+  CUTLASS_DEVICE bool is_producer_load_needed() const { return false; }
+
+  CUTLASS_DEVICE bool is_C_load_needed() const { return false; }
+
+  template <class... Args>
+  CUTLASS_DEVICE auto get_producer_load_callbacks(cutlass::epilogue::fusion::ProducerLoadArgs<Args...> const&) {
+    return cutlass::epilogue::fusion::EmptyProducerLoadCallbacks{};
+  }
+
+  template <class CoordinateTensor, class Residue, class ScaleLayout>
+  struct StoreCallbacks : cutlass::epilogue::fusion::EmptyConsumerStoreCallbacks {
+    CUTLASS_DEVICE StoreCallbacks(CoordinateTensor coordinates, Residue residue, ScaleLayout scale_layout,
+                                  Params const* params, int row_bytes, int tile_row, int tile_column)
+        : coordinates_(coordinates),
+          residue_(residue),
+          scale_layout_(scale_layout),
+          params_(params),
+          row_bytes_(row_bytes),
+          tile_row_(tile_row),
+          tile_column_(tile_column) {}
+
+    template <class ElementAccumulator, class ElementInput, int kFragmentSize>
+    CUTLASS_DEVICE auto visit(cutlass::Array<ElementAccumulator, kFragmentSize> const&, int, int epi_m, int epi_n,
+                              cutlass::Array<ElementInput, kFragmentSize> const& input) {
+      static_assert(kFragmentSize % (2 * kVectorSize) == 0,
+                    "each callback fragment must contain complete gate/up scale blocks");
+      constexpr int kBlocks = kFragmentSize / (2 * kVectorSize);
+
+      auto fragment_coordinates = coordinates_(_, _, _, epi_m, epi_n);
+      const auto first = fragment_coordinates(0);
+      if (elem_less(first, residue_)) {
+        const int row = tile_row_ + get<0>(first);
+        const int merged_column = tile_column_ + get<1>(first);
+        uint8_t* packed = params_->output + static_cast<int64_t>(row) * row_bytes_ + merged_column / 4;
+
+        CUTLASS_PRAGMA_UNROLL
+        for (int block = 0; block < kBlocks; ++block) {
+          const int compact_column = merged_column / 2 + block * kVectorSize;
+          cutlass::Array<ElementCompute, kVectorSize> values;
+          float maximum = 0.0f;
+
+          CUTLASS_PRAGMA_UNROLL
+          for (int index = 0; index < kVectorSize; ++index) {
+            const float gate = static_cast<float>(input[block * 2 * kVectorSize + 2 * index]);
+            const float up = static_cast<float>(input[block * 2 * kVectorSize + 2 * index + 1]);
+            constexpr float kCubicCoefficient = 0.044715f;
+            constexpr float kTanhCoefficient = 1.5957691216057308f;
+            const float activated =
+                gate / (1.0f + expf(-kTanhCoefficient * gate * (1.0f + kCubicCoefficient * gate * gate)));
+            const float value = activated * up;
+            values[index] = static_cast<ElementCompute>(value);
+            maximum = maximum > fabsf(value) ? maximum : fabsf(value);
+          }
+
+          float output_scale = maximum / 6.0f;
+          output_scale = output_scale > 1.0e-12f ? output_scale : 1.0e-12f;
+          __nv_fp8_e4m3 quantized_scale(output_scale);
+          params_->output_scale[scale_layout_(row, compact_column, 0)] = quantized_scale.__x;
+          const float inverse_scale = 1.0f / static_cast<float>(quantized_scale);
+
+          CUTLASS_PRAGMA_UNROLL
+          for (int index = 0; index < kVectorSize; ++index) {
+            values[index] = static_cast<ElementCompute>(values[index] * inverse_scale);
+          }
+
+          auto packed_values =
+              cutlass::NumericArrayConverter<cutlass::float_e2m1_t, ElementCompute, kVectorSize, kRoundStyle>{}(values);
+          *reinterpret_cast<uint2*>(packed + block * (kVectorSize / 2)) =
+              *reinterpret_cast<uint2 const*>(&packed_values);
+        }
+      }
+
+      cutlass::Array<ElementOutput, kFragmentSize> ignored_output;
+      ignored_output.fill(ElementOutput(0));
+      return ignored_output;
+    }
+
+    CoordinateTensor coordinates_;
+    Residue residue_;
+    ScaleLayout scale_layout_;
+    Params const* params_;
+    int row_bytes_;
+    int tile_row_;
+    int tile_column_;
+  };
+
+  template <bool, class... Args>
+  CUTLASS_DEVICE auto get_consumer_store_callbacks(cutlass::epilogue::fusion::ConsumerStoreArgs<Args...> const& args) {
+    auto [m, n, k, l] = args.problem_shape_mnkl;
+    using ScaleConfig = cutlass::detail::Sm1xxBlockScaledConfig<kVectorSize>;
+    auto scale_layout = ScaleConfig::tile_atom_to_shape_SFA(make_shape(m, 1, n / 2, 1));
+    return StoreCallbacks(args.tCcD, args.residue_tCcD, scale_layout, params_, n / 4,
+                          m - static_cast<int>(get<0>(args.residue_tCcD)),
+                          n - static_cast<int>(get<1>(args.residue_tCcD)));
+  }
+
+ private:
+  Params const* params_ = nullptr;
+};
+
+template <int kVectorSize, class ElementOutput, class ElementCompute, class ElementScale, class ScaleLayout,
+          class ElementSource = ElementOutput, class ElementScalar = ElementCompute,
+          cutlass::FloatRoundStyle kRoundStyle = cutlass::FloatRoundStyle::round_to_nearest>
+struct CompactGeGLUFusion
+    : cutlass::epilogue::fusion::LinCombBlockScaleFactor<kVectorSize, ElementOutput, ElementCompute, ElementScale,
+                                                         ScaleLayout, ElementSource, ElementScalar, kRoundStyle> {};
+
+}  // namespace phyai::pi05::thor::detail
+
+namespace cutlass::epilogue::fusion {
+
+template <int kVectorSize, class EpilogueTile, class ElementOutput, class ElementCompute, class ElementScale,
+          class ElementSource, class ElementScalar, cutlass::FloatRoundStyle kRoundStyle>
+using Pi05CompactGeGLUTree =
+    Sm90EVT<phyai::pi05::thor::detail::CompactGeGLUStoreNode<kVectorSize, EpilogueTile, ElementOutput, ElementCompute,
+                                                            ElementScale, kRoundStyle>,
+            Sm90LinearCombination<ElementCompute, ElementCompute, ElementSource, ElementScalar, kRoundStyle>>;
+
+template <int kStagesC, int kStagesD, int kFragmentSize, bool kReuseSmemC, bool kDelayTmaStore, class ElementOutput,
+          class ElementCompute, class ElementScale, int kVectorSize, class ElementSource, class ElementScalar,
+          cutlass::FloatRoundStyle kRoundStyle, class CtaTile, class EpilogueTile>
+struct FusionCallbacks<
+    epilogue::Sm100TmaWarpSpecialized<kStagesC, kStagesD, kFragmentSize, kReuseSmemC, kDelayTmaStore>,
+    phyai::pi05::thor::detail::CompactGeGLUFusion<kVectorSize, ElementOutput, ElementCompute, ElementScale,
+                                                 cutlass::layout::RowMajor, ElementSource, ElementScalar, kRoundStyle>,
+    CtaTile, EpilogueTile>
+    : Pi05CompactGeGLUTree<kVectorSize, EpilogueTile,
+                           typename cutlass::detail::get_unpacked_element_type<ElementOutput>::type, ElementCompute,
+                           ElementScale, ElementSource, ElementScalar, kRoundStyle> {
+  using Impl = Pi05CompactGeGLUTree<kVectorSize, EpilogueTile,
+                                    typename cutlass::detail::get_unpacked_element_type<ElementOutput>::type,
+                                    ElementCompute, ElementScale, ElementSource, ElementScalar, kRoundStyle>;
+
+  struct Arguments {
+    ElementScalar alpha = ElementScalar(1);
+    ElementScalar beta = ElementScalar(0);
+    ElementScalar const* alpha_ptr = nullptr;
+    ElementScalar const* beta_ptr = nullptr;
+    using ScalarStride = cute::Stride<cute::_0, cute::_0, int64_t>;
+    ScalarStride alpha_stride = {cute::_0{}, cute::_0{}, 0};
+    ScalarStride beta_stride = {cute::_0{}, cute::_0{}, 0};
+    uint8_t* output = nullptr;
+    uint8_t* output_scale = nullptr;
+
+    operator typename Impl::Arguments() const {
+      return {{{{beta}, {beta_ptr}, {beta_stride}},
+               {},
+               {{{alpha}, {alpha_ptr}, {alpha_stride}}, {}, {}},
+               {}},
+              {output, output_scale}};
+    }
+  };
+
+  using Impl::Impl;
+};
+
+}  // namespace cutlass::epilogue::fusion

--- a/phyai-kernel/phyai_kernel/cuda/pi05_thor_nvfp4_geglu.py
+++ b/phyai-kernel/phyai_kernel/cuda/pi05_thor_nvfp4_geglu.py
@@ -1,0 +1,251 @@
+"""SM110 NVFP4 Gate+Up+GeGLU kernel for the pi0.5 language MLP."""
+
+from __future__ import annotations
+
+import os
+import re
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from phyai_kernel.jit_utils import PHYAI_KERNEL_CUDA_CSRC_DIR, jit
+
+
+SUPPORTED_M = frozenset({784, 816, 880, 968})
+HIDDEN_SIZE = 2048
+INTERMEDIATE_SIZE = 16384
+MERGED_SIZE = 2 * INTERMEDIATE_SIZE
+_MIN_CUTLASS_VERSION = (4, 4, 2)
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def nvfp4_scale_shape(rows: int, cols: int) -> tuple[int, int]:
+    """Return FlashInfer/CUTLASS 128x4 scale storage for an NVFP4 matrix."""
+    if rows <= 0 or cols <= 0 or cols % 16 != 0:
+        raise ValueError("rows must be positive and cols must be divisible by 16")
+    return ((rows + 127) // 128 * 128, (cols // 16 + 3) // 4 * 4)
+
+
+def _cutlass_version(root: Path) -> tuple[int, int, int] | None:
+    version_header = root / "include" / "cutlass" / "version.h"
+    if not version_header.is_file():
+        return None
+    text = version_header.read_text(encoding="utf-8")
+    values = []
+    for field in ("MAJOR", "MINOR", "PATCH"):
+        match = re.search(rf"^#define CUTLASS_{field}\s+(\d+)$", text, re.MULTILINE)
+        if match is None:
+            return None
+        values.append(int(match.group(1)))
+    return tuple(values)  # type: ignore[return-value]
+
+
+def _resolve_cutlass_root() -> Path:
+    candidates: list[Path] = []
+    configured = os.environ.get("PHYAI_CUTLASS_ROOT")
+    if configured:
+        candidates.append(Path(configured).expanduser())
+    candidates.append(_REPOSITORY_ROOT / "third_party" / "mirage" / "deps" / "cutlass")
+
+    flashinfer_spec = find_spec("flashinfer")
+    if flashinfer_spec is not None and flashinfer_spec.submodule_search_locations:
+        candidates.extend(
+            Path(location) / "data" / "cutlass"
+            for location in flashinfer_spec.submodule_search_locations
+        )
+
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        version = _cutlass_version(resolved)
+        if version is not None and version >= _MIN_CUTLASS_VERSION:
+            return resolved
+    return candidates[0].resolve()
+
+
+_CUTLASS_ROOT = _resolve_cutlass_root()
+_CUTLASS_INCLUDE_PATHS = (
+    _CUTLASS_ROOT / "include",
+    _CUTLASS_ROOT / "tools" / "util" / "include",
+)
+
+
+@jit(
+    device="cuda",
+    func_name="phyai_pi05_thor_nvfp4_geglu",
+    cuda_files=["pi05_thor_nvfp4_geglu.cuh"],
+    cpp_wrappers=[],
+    cuda_wrappers=[("phyai_pi05_thor_nvfp4_geglu", "phyai_pi05_thor_nvfp4_geglu")],
+    extra_cuda_cxx_flags=[
+        "-DNDEBUG",
+        "--use_fast_math",
+        "-gencode=arch=compute_110a,code=sm_110a",
+    ],
+    extra_include_paths=[str(path) for path in _CUTLASS_INCLUDE_PATHS],
+    build_directory=os.environ.get("PHYAI_PI05_THOR_NVFP4_BUILD_DIR"),
+)
+def _launch(
+    compiled_module: Any,
+    activation: torch.Tensor,
+    activation_scale: torch.Tensor,
+    interleaved_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    output: torch.Tensor,
+    output_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m = activation.shape[0]
+    stream = int(torch.cuda.current_stream(activation.device).cuda_stream)
+    return_code = compiled_module.phyai_pi05_thor_nvfp4_geglu(
+        activation,
+        activation_scale,
+        interleaved_weight,
+        weight_scale,
+        workspace,
+        output,
+        output_scale,
+        m,
+        stream,
+    )
+    if return_code != 0:
+        raise RuntimeError(
+            f"pi0.5 Thor NVFP4 GeGLU failed with return code {return_code}"
+        )
+    return output, output_scale
+
+
+def _contract_error(
+    activation: torch.Tensor,
+    activation_scale: torch.Tensor,
+    interleaved_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    output: torch.Tensor,
+    output_scale: torch.Tensor,
+) -> str | None:
+    tensors = (
+        activation,
+        activation_scale,
+        interleaved_weight,
+        weight_scale,
+        workspace,
+        output,
+        output_scale,
+    )
+    if any(not tensor.is_cuda for tensor in tensors):
+        return "all tensors must be CUDA tensors"
+    if any(tensor.requires_grad for tensor in tensors):
+        return "the kernel is inference-only"
+    if any(tensor.dtype != torch.uint8 for tensor in tensors):
+        return "all packed values and scales must use uint8 storage"
+    if any(not tensor.is_contiguous() for tensor in tensors):
+        return "all tensors must be contiguous"
+    if any(tensor.device != activation.device for tensor in tensors[1:]):
+        return "all tensors must be on the same device"
+    if activation.ndim != 2:
+        return "activation must be a 2-D packed NVFP4 tensor"
+
+    m = activation.shape[0]
+    expected_shapes = {
+        "activation": (m, HIDDEN_SIZE // 2),
+        "activation_scale": nvfp4_scale_shape(m, HIDDEN_SIZE),
+        "interleaved_weight": (MERGED_SIZE, HIDDEN_SIZE // 2),
+        "weight_scale": nvfp4_scale_shape(MERGED_SIZE, HIDDEN_SIZE),
+        "workspace": (m, INTERMEDIATE_SIZE),
+        "output": (m, INTERMEDIATE_SIZE // 2),
+        "output_scale": nvfp4_scale_shape(m, INTERMEDIATE_SIZE),
+    }
+    actual = {
+        "activation": tuple(activation.shape),
+        "activation_scale": tuple(activation_scale.shape),
+        "interleaved_weight": tuple(interleaved_weight.shape),
+        "weight_scale": tuple(weight_scale.shape),
+        "workspace": tuple(workspace.shape),
+        "output": tuple(output.shape),
+        "output_scale": tuple(output_scale.shape),
+    }
+    if m not in SUPPORTED_M:
+        return f"unsupported token count M={m}"
+    for name, expected in expected_shapes.items():
+        if actual[name] != expected:
+            return f"{name} must have shape {expected}, got {actual[name]}"
+    if torch.cuda.get_device_capability(activation.device) != (11, 0):
+        return "the kernel requires SM110"
+    version = _cutlass_version(_CUTLASS_ROOT)
+    if version is None or version < _MIN_CUTLASS_VERSION:
+        return "CUTLASS 4.4.2 or newer is required"
+    return None
+
+
+def supports_pi05_thor_nvfp4_geglu(
+    activation: torch.Tensor,
+    activation_scale: torch.Tensor,
+    interleaved_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    output: torch.Tensor,
+    output_scale: torch.Tensor,
+) -> bool:
+    """Return whether tensors satisfy the fixed pi0.5 SM110 NVFP4 contract."""
+    return (
+        _contract_error(
+            activation,
+            activation_scale,
+            interleaved_weight,
+            weight_scale,
+            workspace,
+            output,
+            output_scale,
+        )
+        is None
+    )
+
+
+def pi05_thor_nvfp4_geglu(
+    activation: torch.Tensor,
+    activation_scale: torch.Tensor,
+    interleaved_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    output: torch.Tensor,
+    output_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the fixed SM110 schedule into caller-owned NVFP4 output buffers.
+
+    Inputs and weights must use CUTLASS/FlashInfer 128x4 scale storage and a
+    global scale of one. Weight rows are pairwise interleaved as
+    ``gate0, up0, gate1, up1, ...``. Caller-owned buffers keep allocations out
+    of CUDA Graph capture.
+    """
+    error = _contract_error(
+        activation,
+        activation_scale,
+        interleaved_weight,
+        weight_scale,
+        workspace,
+        output,
+        output_scale,
+    )
+    if error is not None:
+        raise ValueError(error)
+    return _launch(
+        activation,
+        activation_scale,
+        interleaved_weight,
+        weight_scale,
+        workspace,
+        output,
+        output_scale,
+    )
+
+
+__all__ = [
+    "HIDDEN_SIZE",
+    "INTERMEDIATE_SIZE",
+    "MERGED_SIZE",
+    "SUPPORTED_M",
+    "nvfp4_scale_shape",
+    "pi05_thor_nvfp4_geglu",
+    "supports_pi05_thor_nvfp4_geglu",
+]

--- a/phyai-kernel/tests/test_pi05_thor_nvfp4_geglu.py
+++ b/phyai-kernel/tests/test_pi05_thor_nvfp4_geglu.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from phyai_kernel.cuda.pi05_thor_nvfp4_geglu import (
+    HIDDEN_SIZE,
+    INTERMEDIATE_SIZE,
+    MERGED_SIZE,
+    nvfp4_scale_shape,
+    pi05_thor_nvfp4_geglu,
+    supports_pi05_thor_nvfp4_geglu,
+)
+
+
+def test_nvfp4_scale_shape_matches_128x4_layout():
+    assert nvfp4_scale_shape(784, HIDDEN_SIZE) == (896, 128)
+    assert nvfp4_scale_shape(MERGED_SIZE, HIDDEN_SIZE) == (32768, 128)
+    assert nvfp4_scale_shape(784, INTERMEDIATE_SIZE) == (896, 1024)
+
+
+def test_nvfp4_scale_shape_rejects_invalid_dimensions():
+    with pytest.raises(ValueError, match="rows must be positive"):
+        nvfp4_scale_shape(0, HIDDEN_SIZE)
+    with pytest.raises(ValueError, match="divisible by 16"):
+        nvfp4_scale_shape(1, 15)
+
+
+def test_host_tensors_do_not_select_thor_kernel():
+    tensors = [torch.empty(1, dtype=torch.uint8) for _ in range(7)]
+    assert not supports_pi05_thor_nvfp4_geglu(*tensors)
+    with pytest.raises(ValueError, match="CUDA tensors"):
+        pi05_thor_nvfp4_geglu(*tensors)
+
+
+def _thor_test_enabled() -> bool:
+    return bool(
+        os.environ.get("PHYAI_RUN_THOR_KERNEL_TESTS") == "1"
+        and torch.cuda.is_available()
+        and torch.cuda.get_device_capability() == (11, 0)
+    )
+
+
+@pytest.mark.skipif(
+    not _thor_test_enabled(),
+    reason="set PHYAI_RUN_THOR_KERNEL_TESTS=1 on an SM110 device",
+)
+def test_thor_nvfp4_geglu_correctness_and_graph_capture():
+    from flashinfer import gemm as flashinfer_gemm
+    from flashinfer.quantization import SfLayout, nvfp4_quantize
+
+    m = 784
+    generator = torch.Generator(device="cuda").manual_seed(20260814)
+    x = torch.randn(
+        m,
+        HIDDEN_SIZE,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    interleaved_weight_bf16 = (
+        torch.randn(
+            MERGED_SIZE,
+            HIDDEN_SIZE,
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.02
+    )
+    down_weight_bf16 = (
+        torch.randn(
+            HIDDEN_SIZE,
+            INTERMEDIATE_SIZE,
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.02
+    )
+    global_scale = torch.ones(1, dtype=torch.float32, device="cuda")
+    activation, activation_scale = nvfp4_quantize(
+        x,
+        global_scale,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+        enable_pdl=False,
+    )
+    interleaved_weight, weight_scale = nvfp4_quantize(
+        interleaved_weight_bf16,
+        global_scale,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+        enable_pdl=False,
+    )
+    down_weight, down_weight_scale = nvfp4_quantize(
+        down_weight_bf16,
+        global_scale,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+        enable_pdl=False,
+    )
+    workspace = torch.zeros(m, INTERMEDIATE_SIZE, dtype=torch.uint8, device="cuda")
+    output = torch.empty(m, INTERMEDIATE_SIZE // 2, dtype=torch.uint8, device="cuda")
+    output_scale = torch.zeros(
+        nvfp4_scale_shape(m, INTERMEDIATE_SIZE),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+
+    assert supports_pi05_thor_nvfp4_geglu(
+        activation,
+        activation_scale,
+        interleaved_weight,
+        weight_scale,
+        workspace,
+        output,
+        output_scale,
+    )
+    pi05_thor_nvfp4_geglu(
+        activation,
+        activation_scale,
+        interleaved_weight,
+        weight_scale,
+        workspace,
+        output,
+        output_scale,
+    )
+    torch.cuda.synchronize()
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        pi05_thor_nvfp4_geglu(
+            activation,
+            activation_scale,
+            interleaved_weight,
+            weight_scale,
+            workspace,
+            output,
+            output_scale,
+        )
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        pi05_thor_nvfp4_geglu(
+            activation,
+            activation_scale,
+            interleaved_weight,
+            weight_scale,
+            workspace,
+            output,
+            output_scale,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    actual = flashinfer_gemm.mm_fp4(
+        output,
+        down_weight.t(),
+        output_scale,
+        down_weight_scale.t().view(torch.uint8),
+        global_scale,
+        torch.bfloat16,
+        None,
+        block_size=16,
+        use_nvfp4=True,
+        backend="cudnn",
+    )
+    staged_merged = flashinfer_gemm.mm_fp4(
+        activation,
+        interleaved_weight.t(),
+        activation_scale,
+        weight_scale.t().view(torch.uint8),
+        global_scale,
+        torch.bfloat16,
+        None,
+        block_size=16,
+        use_nvfp4=True,
+        backend="cudnn",
+    )
+    staged_hidden = (
+        F.gelu(staged_merged[:, 0::2], approximate="tanh") * staged_merged[:, 1::2]
+    )
+    staged_output, staged_output_scale = nvfp4_quantize(
+        staged_hidden,
+        global_scale,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+        enable_pdl=False,
+    )
+    expected = flashinfer_gemm.mm_fp4(
+        staged_output,
+        down_weight.t(),
+        staged_output_scale,
+        down_weight_scale.t().view(torch.uint8),
+        global_scale,
+        torch.bfloat16,
+        None,
+        block_size=16,
+        use_nvfp4=True,
+        backend="cudnn",
+    )
+    difference = actual.float() - expected.float()
+    relative_l2 = torch.linalg.vector_norm(difference) / torch.linalg.vector_norm(
+        expected.float()
+    ).clamp_min(1.0e-12)
+    cosine = F.cosine_similarity(
+        actual.float().flatten(), expected.float().flatten(), dim=0
+    )
+    assert relative_l2.item() < 0.05
+    assert cosine.item() > 0.999


### PR DESCRIPTION
## Summary

This Draft PR adds an opt-in SM110 NVFP4 Gate+Up+GeGLU kernel for the fixed
pi0.5 language MLP shapes. The kernel fuses the merged gate/up projection,
GeGLU fold, and compact NVFP4 output store. Its output can feed the existing
NVFP4 down projection without a BF16 intermediate or a separate quantization
launch.

The compact epilogue is implemented in phyAI against CUTLASS callback
interfaces. The PR does not vendor, include, or depend on FlashRT source.

This is a low-level kernel API. It does not change pi0.5 model dispatch, weight
loading, conversion, or the default `DenseMLP` path.

## Review map

1. `phyai_kernel/cuda/pi05_thor_nvfp4_geglu.py` defines the public contract,
   fail-closed validation, caller-owned buffers, SM110 guard, and JIT build.
2. `cuda/csrc/pi05_thor_nvfp4_geglu.cuh` contains the fixed
   `128x256x256` tile, `1x2x1` cluster schedule, and TVM-FFI boundary.
3. `cuda/csrc/pi05_thor_nvfp4_geglu_epilogue.cuh` implements the phyAI-owned
   GeGLU fold, per-block scale generation, packed E2M1 store, and CUTLASS
   fusion callback.
4. `tests/test_pi05_thor_nvfp4_geglu.py` covers the shape and storage contract,
   numerical comparison, failure paths, and CUDA Graph capture.
5. `benchmark/bench_pi05_thor_nvfp4_geglu.py` defines the matched staged
   baseline and raw-sample timing protocol.

## Supported contract

| Surface | Contract |
|---|---|
| Device | NVIDIA SM110 |
| Shapes | `M in {784, 816, 880, 968}`, `K=2048`, merged `N=32768`, hidden `H=16384` |
| Values | Packed NVFP4 E2M1 activation and weight values |
| Scales | FP8 E4M3 in CUTLASS/FlashInfer 128x4 layout, global scale 1 |
| Weight layout | Pairwise-interleaved gate/up rows: `gate0, up0, gate1, up1, ...` |
| Output | Packed NVFP4 hidden activation and scale factors for the down projection |
| Ownership | Caller supplies output and workspace buffers |
| Fallback | No fallback is hidden inside the API. Unsupported inputs fail before launch |
| Dispatch | Explicit opt-in only. Existing model dispatch remains unchanged |

Numerical checks compare the consumed down-projection result with the staged
NVFP4 path. The frozen gate is relative-L2 below 0.05 and cosine above 0.999.

## Validation

Current product commit: `e44875cce92374002339164b123624cb9295fc35`.

| Gate | Status | Evidence boundary |
|---|---:|---|
| Repository pre-commit checks | PASS | clang-format, codespell, ruff-format, and diff checks on the seven-file product diff |
| Fresh Thor JIT build | PASS | Current source built native SM110 and SM110a images on Jetson Thor |
| Focused Thor tests | PASS, 4 tests | Host rejection paths, numerical tolerance through the NVFP4 down projection, launch, and CUDA Graph capture/replay |
| Code generation and resources | PASS with changed code | Both images use 255 registers and 1024 bytes static shared memory. The SM110a image has no stack or LDL instruction |
| Accepted performance matrix | PENDING | Device code changed after the source cleanup, so earlier timing is not inherited |
| Local macOS target pytest | BLOCKED | The host environment has no Triton installation. Target correctness is covered by the fresh Thor run |
| Upstream CI | PENDING | Draft PR gate |

The current source contains no FlashRT vendored file or include. The first
published Draft revision did, and its performance and model screens are no
longer used as current-source evidence.

## Performance evidence

**Evidence boundary:** performance qualification is pending an uncontended Thor
window. Two unrelated GPU-resident policy servers are active on the shared
device, so their timing is excluded from the PR claim.

**Setup:** the checked-in benchmark freezes the intended run contract. Timing
is reported in ms.

- CUDA Graph replay timed with CUDA events.
- 25 warmups, 30 raw samples per shape, and 20 replays per sample.
- Alternating candidate and baseline order with no outlier filtering.
- Baseline: FlashInfer NVFP4 merged GEMM, PyTorch GeGLU, then FlashInfer NVFP4
  quantization.
- Matched endpoints: both paths start with the same packed NVFP4 activation and
  interleaved weight, and end with packed NVFP4 hidden activation and scales.

Results in milliseconds, per-shape speedups, the primary geometric mean, and
the worst row will be added after the current source passes that full matrix.
The 18-layer checkpoint workset and temporary model integration screen will
also be rerun before this Draft is promoted.

## Files changed

- Public API and exports: three Python files.
- CUDA implementation: the fixed GEMM header and one phyAI-owned epilogue
  header.
- Validation: one focused test and one benchmark.

The PR contains 7 changed files with 1,063 additions and 1 deletion.
Experimental harnesses, generated artifacts, model weights, rejected schedules,
and model integration patches are excluded.

## Known limits

- The fast path supports SM110 and the four observed pi0.5 token counts only.
- CUTLASS 4.4.2 or newer is required. The validated environment selected the
  copy bundled with FlashInfer.
- Callers must provide pairwise-interleaved weights, global scale 1, and
  caller-owned workspace and output buffers.
- No production model dispatch, automatic fallback, or weight preparation is
  included. Unsupported contracts fail closed and the existing MLP path is
  unchanged.
- Numerical validation establishes parity with the staged NVFP4 recipe. It is
  not calibrated model-quality or task-quality evidence.
- The PR remains Draft until the current source completes uncontended kernel,
  18-layer MLP, and temporary model integration performance screens.
